### PR TITLE
eclipse-attack-pretending-not-to-know

### DIFF
--- a/compositions/eclipse-attack-pretending-not-to-know.toml
+++ b/compositions/eclipse-attack-pretending-not-to-know.toml
@@ -1,0 +1,25 @@
+[metadata]
+name = "eclipse-attack-pretending-not-to-know"
+author = "Akihito Nakano"
+
+[global]
+plan = "discv5-testground"
+case = "eclipse-attack-pretending-not-to-know"
+total_instances = 20
+builder = "docker:generic"
+runner = "local:docker"
+disable_metrics = false
+
+[[groups]]
+id = "victim"
+  [groups.instances]
+  count = 1
+  [groups.run]
+    [groups.run.test_params]
+
+[[groups]]
+id = "attackers"
+  [groups.instances]
+  count = 19
+  [groups.run]
+    [groups.run.test_params]

--- a/manifest.toml
+++ b/manifest.toml
@@ -30,3 +30,14 @@ instances = { min = 20, max = 20, default = 20 }
 
   # Params for the `victim` group
   incoming_bucket_limit = { type = "int", desc = "A maximum limit to the number of incoming nodes per bucket.", default = 16 }
+
+# Eclipse attack by pretending not to know the victim node
+[[testcases]]
+name = "eclipse-attack-pretending-not-to-know"
+# The number of `instances` is fixed to 20 in this test case. For more detail,
+# see `compositions/eclipse-attack-pretending-not-to-know.toml`.
+instances = { min = 20, max = 20, default = 20 }
+
+  [testcases.params]
+  latency = { type = "int", desc = "Latency between peers.", unit = "ms", default = 100 }
+

--- a/src/main.rs
+++ b/src/main.rs
@@ -76,7 +76,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 .await?
         }
         "eclipse-attack-pretending-not-to-know" => {
-            eclipse::pretending_not_to_know::PretendingNotToKnow::new(run_parameters)
+            eclipse::pretending_not_to_know::PretendingNotToKnow {}
                 .run(client.clone())
                 .await?
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -74,6 +74,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 .run(client.clone())
                 .await?
         }
+        "eclipse-attack-pretending-not-to-know" => {
+            eclipse::pretending_not_to_know::PretendingNotToKnow::new(run_parameters)
+                .run(client.clone())
+                .await?
+        }
         _ => unreachable!(),
     };
 


### PR DESCRIPTION
The attackers could fill the victim's "outbound" slot on his routing table by pretending not to know the victim after a handshake.

https://github.com/ackintosh/discv5-testground/issues/22#issuecomment-1161842341


<img width="1252" alt="image" src="https://user-images.githubusercontent.com/1885716/174969748-7a083684-0aa0-42b2-82b4-6106c1da548b.png">
