### PR TITLE
`--locked` flag for `cargo install`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /usr/src/test-plan
 # See https://blog.mgattozzi.dev/caching-rust-docker-builds/
 # And https://github.com/rust-lang/cargo/issues/2644
 RUN mkdir -p ./plan/src/
-RUN echo "fn main() {}" > ./plan/src/main.rs
+RUN echo 'fn main() { println!("This is a `main()` function that does nothing, for caching dependencies.") }' > ./plan/src/main.rs
 COPY ./plan/Cargo.lock ./plan/
 COPY ./plan/Cargo.toml ./plan/
 RUN cd ./plan/ && cargo build --release
@@ -13,7 +13,7 @@ RUN cd ./plan/ && cargo build --release
 COPY . .
 # In `docker:generic` builder, the root of the docker build context is one directory higher than this test plan
 # https://docs.testground.ai/builder-library/docker-generic#usage
-RUN cd plan && cargo install --path .
+RUN cd plan && cargo install --locked --path .
 
 FROM debian:bullseye-slim
 COPY --from=builder /usr/local/cargo/bin/discv5-testground /usr/local/bin/discv5-testground

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,11 @@ COPY ./plan/Cargo.toml ./plan/
 RUN cd ./plan/ && cargo build --release
 
 COPY . .
+
+# This is in order to make sure `main.rs`s mtime timestamp is updated.
+# https://github.com/rust-lang/cargo/issues/9598
+RUN touch ./plan/src/main.rs
+
 # In `docker:generic` builder, the root of the docker build context is one directory higher than this test plan
 # https://docs.testground.ai/builder-library/docker-generic#usage
 RUN cd plan && cargo install --locked --path .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.61-bullseye as builder
+FROM rust:1.62-bullseye as builder
 WORKDIR /usr/src/test-plan
 
 # Cache dependencies between test runs,

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,14 +5,15 @@ WORKDIR /usr/src/test-plan
 # See https://blog.mgattozzi.dev/caching-rust-docker-builds/
 # And https://github.com/rust-lang/cargo/issues/2644
 RUN mkdir -p ./plan/src/
-RUN echo 'fn main() { println!("This is a `main()` function that does nothing, for caching dependencies.") }' > ./plan/src/main.rs
+RUN echo "fn main() { println!(\"If you see this message, you may want to clean up the target directory or the Docker build cache.\") }" > ./plan/src/main.rs
 COPY ./plan/Cargo.lock ./plan/
 COPY ./plan/Cargo.toml ./plan/
 RUN cd ./plan/ && cargo build --release
 
 COPY . .
 
-# This is in order to make sure `main.rs`s mtime timestamp is updated.
+# This is in order to make sure `main.rs`s mtime timestamp is updated to avoid the dummy `main`
+# remaining in the release binary.
 # https://github.com/rust-lang/cargo/issues/9598
 RUN touch ./plan/src/main.rs
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,7 @@ const STATE_NETWORK_CONFIGURED: &str = "state_network_configured";
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let client = testground::client::Client::new_and_init().await?;
+    let client = Client::new_and_init().await?;
 
     // Enable tracing.
     let env_filter = tracing_subscriber::EnvFilter::try_from_default_env()


### PR DESCRIPTION
`cargo install` ignores Cargo.lock by default. Now builds on this project are failing due to incompatibility of `enr v0.6.1`, which is a dependency of `discv5`. Note: Currently we are using `discv5` on master branch, not published on crates.io.

In order to fix the build error, added `--locked` flag so that `cargo install` respects Cargo.lock.