### PR TITLE
concurrent requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,13 +55,14 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.7.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
+checksum = "77c3a9648d43b9cd48db467b3f87fdd6e146bcc88ab0180006cef2179fe11d01"
 dependencies = [
- "getrandom",
+ "cfg-if",
  "once_cell",
  "version_check",
+ "zerocopy",
 ]
 
 [[package]]
@@ -72,6 +73,12 @@ checksum = "43f6cb1bf222025340178f382c426f13757b2960e89779dfcb319c32542a5a41"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
 
 [[package]]
 name = "android-tzdata"
@@ -336,7 +343,7 @@ checksum = "83fdaf97f4804dcebfa5862639bc9ce4121e82140bec2a987ac5140294865b5b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -360,7 +367,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.28",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -371,7 +378,7 @@ checksum = "29a358ff9f12ec09c3e61fef9b5a9902623a695a46a917b07f269bff1445611a"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -417,14 +424,15 @@ dependencies = [
 
 [[package]]
 name = "discv5"
-version = "0.3.1"
-source = "git+https://github.com/ackintosh/discv5.git?rev=e6df09a0f32000ae5618d5f2f84413817df3b6e1#e6df09a0f32000ae5618d5f2f84413817df3b6e1"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b0b31b65aa1fcbd4e0171f1afed5363ccf25efb988ecd42450036f4c6d8539"
 dependencies = [
  "aes",
  "aes-gcm",
  "arrayvec",
  "delay_map",
- "enr",
+ "enr 0.10.0",
  "fnv",
  "futures",
  "hashlink",
@@ -452,7 +460,7 @@ dependencies = [
  "aes-gcm",
  "chrono",
  "discv5",
- "enr",
+ "enr 0.9.1",
  "hkdf",
  "rand",
  "rand_xorshift",
@@ -538,6 +546,25 @@ name = "enr"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe81b5c06ecfdbc71dd845216f225f53b62a10cb8a16c946836a3467f701d05b"
+dependencies = [
+ "base64 0.21.2",
+ "bytes",
+ "ed25519-dalek",
+ "hex",
+ "k256",
+ "log",
+ "rand",
+ "rlp",
+ "serde",
+ "sha3",
+ "zeroize",
+]
+
+[[package]]
+name = "enr"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a3d8dc56e02f954cac8eb489772c552c473346fc34f67412bb6244fd647f7e4"
 dependencies = [
  "base64 0.21.2",
  "bytes",
@@ -639,7 +666,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -742,29 +769,27 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
-dependencies = [
- "ahash",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hashbrown"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 dependencies = [
  "ahash",
+ "allocator-api2",
 ]
 
 [[package]]
 name = "hashlink"
-version = "0.7.0"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7249a3129cbc1ffccd74857f81464a323a152173cdb134e0fd81bc803b29facf"
+checksum = "e8094feaf31ff591f651a2664fb9cfd92bba7a60ce3197265e9482ebe753c8f7"
 dependencies = [
- "hashbrown 0.11.2",
+ "hashbrown 0.14.3",
 ]
 
 [[package]]
@@ -946,7 +971,7 @@ checksum = "6ac96b3660efd0cde32b0b20bc86cc93f33269cd9f6c97e759e0b0259b2133fb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -1041,11 +1066,11 @@ checksum = "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4"
 
 [[package]]
 name = "lru"
-version = "0.7.8"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e999beba7b6e8345721bd280141ed958096a2e4abdf74f67ff4ce49b4b54e47a"
+checksum = "2994eeba8ed550fd9b47a0b38f0242bc3344e496483c6180b69139cc2fa5d1d7"
 dependencies = [
- "hashbrown 0.12.3",
+ "hashbrown 0.14.3",
 ]
 
 [[package]]
@@ -1091,9 +1116,9 @@ dependencies = [
 
 [[package]]
 name = "more-asserts"
-version = "0.2.2"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7843ec2de400bcbc6a6328c958dc38e5359da6e93e72e37bc5246bf1ae776389"
+checksum = "1fafa6961cabd9c63bcd77a45d7e3b7f3b552b70417831fb0f56db717e72407e"
 
 [[package]]
 name = "nu-ansi-term"
@@ -1480,7 +1505,7 @@ checksum = "43576ca501357b9b071ac53cdc7da8ef0cbd9493d8df094cd821777ea6e894d3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -1502,7 +1527,7 @@ checksum = "bcec881020c684085e55a25f7fd888954d56609ef363479dc5a1305eb0d40cab"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -1536,7 +1561,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -1683,9 +1708,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.28"
+version = "2.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04361975b3f5e348b2189d8dc55bc942f278b2d482a6a0365de5bdd62d351567"
+checksum = "239814284fd6f1a4ffe4ca893952cdd93c224b6a1571c9a9eadd670295c0c9e2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1738,7 +1763,7 @@ checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -1791,7 +1816,7 @@ checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -1847,7 +1872,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -2003,7 +2028,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.32",
  "wasm-bindgen-shared",
 ]
 
@@ -2037,7 +2062,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.32",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -2165,6 +2190,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "zerocopy"
+version = "0.7.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74d4d3961e53fa4c9a25a8637fc2bfaf2595b3d3ae34875568a5cf64787716be"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.32",
+]
+
+[[package]]
 name = "zeroize"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2181,5 +2226,5 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.32",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -428,7 +428,7 @@ dependencies = [
 [[package]]
 name = "discv5"
 version = "0.3.1"
-source = "git+https://github.com/njgheorghita/discv5.git?rev=09262ead2882e062de1a6a45df9ea61917eb8465#09262ead2882e062de1a6a45df9ea61917eb8465"
+source = "git+https://github.com/ackintosh/discv5.git?rev=337be4b135cd8ddd71a081d37bcba19c8cfe6342#337be4b135cd8ddd71a081d37bcba19c8cfe6342"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -459,8 +459,10 @@ dependencies = [
 name = "discv5-testground"
 version = "0.1.0"
 dependencies = [
+ "aes-gcm",
  "chrono",
  "discv5",
+ "enr",
  "hkdf",
  "rand",
  "rand_xorshift",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -428,7 +428,7 @@ dependencies = [
 [[package]]
 name = "discv5"
 version = "0.3.1"
-source = "git+https://github.com/ackintosh/discv5.git?rev=90bcd002c3ef711b1558c4a6989e4b65f7737718#90bcd002c3ef711b1558c4a6989e4b65f7737718"
+source = "git+https://github.com/ackintosh/discv5.git?rev=e6df09a0f32000ae5618d5f2f84413817df3b6e1#e6df09a0f32000ae5618d5f2f84413817df3b6e1"
 dependencies = [
  "aes",
  "aes-gcm",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -313,9 +313,9 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "4.0.0-rc.3"
+version = "4.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "436ace70fc06e06f7f689d2624dc4e2f0ea666efb5aa704215f7249ae6e047a7"
+checksum = "e89b8c6a2e4b1f45971ad09761aafb85514a84744b67a95e32c3cc1352d1f65c"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -417,8 +417,8 @@ dependencies = [
 
 [[package]]
 name = "discv5"
-version = "0.3.0"
-source = "git+https://github.com/sigp/discv5.git?rev=a9ded0490229418cb61e747d55d3e0879b62e1d7#a9ded0490229418cb61e747d55d3e0879b62e1d7"
+version = "0.3.1"
+source = "git+https://github.com/ackintosh/discv5.git?rev=e6df09a0f32000ae5618d5f2f84413817df3b6e1#e6df09a0f32000ae5618d5f2f84413817df3b6e1"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -449,8 +449,12 @@ dependencies = [
 name = "discv5-testground"
 version = "0.1.0"
 dependencies = [
+ "aes-gcm",
  "chrono",
  "discv5",
+ "enr",
+ "hkdf",
+ "rand",
  "rand_xorshift",
  "serde",
  "serde_json",
@@ -459,6 +463,7 @@ dependencies = [
  "tokio-stream",
  "tracing",
  "tracing-subscriber",
+ "zeroize",
 ]
 
 [[package]]
@@ -487,15 +492,16 @@ dependencies = [
 
 [[package]]
 name = "ed25519-dalek"
-version = "2.0.0-rc.3"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "faa8e9049d5d72bfc12acbc05914731b5322f79b5e2f195e9f2d705fca22ab4c"
+checksum = "1f628eaec48bfd21b865dc2950cfa014450c01d2fa2b69a86c2fd5844ec523c0"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
  "rand_core",
  "serde",
  "sha2",
+ "subtle",
  "zeroize",
 ]
 
@@ -529,11 +535,11 @@ dependencies = [
 
 [[package]]
 name = "enr"
-version = "0.8.1"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf56acd72bb22d2824e66ae8e9e5ada4d0de17a69c7fd35569dde2ada8ec9116"
+checksum = "fe81b5c06ecfdbc71dd845216f225f53b62a10cb8a16c946836a3467f701d05b"
 dependencies = [
- "base64 0.13.1",
+ "base64 0.21.2",
  "bytes",
  "ed25519-dalek",
  "hex",
@@ -558,9 +564,9 @@ dependencies = [
 
 [[package]]
 name = "fiat-crypto"
-version = "0.1.20"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e825f6987101665dea6ec934c09ec6d721de7bc1bf92248e1d5810c8cd636b77"
+checksum = "27573eac26f4dd11e2b1916c3fe1baa56407c83c71a773a8ba17ec0bca03b6b7"
 
 [[package]]
 name = "fnv"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -419,7 +419,7 @@ dependencies = [
 [[package]]
 name = "discv5"
 version = "0.3.0"
-source = "git+https://github.com/sigp/discv5.git?rev=a9ded0490229418cb61e747d55d3e0879b62e1d7#a9ded0490229418cb61e747d55d3e0879b62e1d7"
+source = "git+https://github.com/ackintosh/discv5.git?rev=5e4503f6d05e6f5be9b091bc8bb2032630be2e9f#5e4503f6d05e6f5be9b091bc8bb2032630be2e9f"
 dependencies = [
  "aes",
  "aes-gcm",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -419,7 +419,7 @@ dependencies = [
 [[package]]
 name = "discv5"
 version = "0.3.0"
-source = "git+https://github.com/ackintosh/discv5.git?rev=99452cd550944a352e7047f329b097d3cfb04e4b#99452cd550944a352e7047f329b097d3cfb04e4b"
+source = "git+https://github.com/ackintosh/discv5.git?rev=730db0976edcf91a0d3736ca168b358844c9cbe2#730db0976edcf91a0d3736ca168b358844c9cbe2"
 dependencies = [
  "aes",
  "aes-gcm",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,6 +89,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "array-init"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23589ecb866b460d3a0f1278834750268c607e8e28a1b982c907219f3178cd72"
+dependencies = [
+ "nodrop",
+]
+
+[[package]]
 name = "arrayvec"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -418,8 +427,8 @@ dependencies = [
 
 [[package]]
 name = "discv5"
-version = "0.3.0"
-source = "git+https://github.com/ackintosh/discv5.git?rev=730db0976edcf91a0d3736ca168b358844c9cbe2#730db0976edcf91a0d3736ca168b358844c9cbe2"
+version = "0.3.1"
+source = "git+https://github.com/njgheorghita/discv5.git?rev=32b2240a8f6466969aec3215abf62db9edfadb13#32b2240a8f6466969aec3215abf62db9edfadb13"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -437,7 +446,7 @@ dependencies = [
  "parking_lot",
  "rand",
  "rlp",
- "smallvec",
+ "smallvec 1.10.0",
  "socket2",
  "tokio",
  "tracing",
@@ -452,6 +461,8 @@ version = "0.1.0"
 dependencies = [
  "chrono",
  "discv5",
+ "hkdf",
+ "rand",
  "rand_xorshift",
  "serde",
  "serde_json",
@@ -460,6 +471,7 @@ dependencies = [
  "tokio-stream",
  "tracing",
  "tracing-subscriber",
+ "zeroize",
 ]
 
 [[package]]
@@ -530,11 +542,11 @@ dependencies = [
 
 [[package]]
 name = "enr"
-version = "0.8.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf56acd72bb22d2824e66ae8e9e5ada4d0de17a69c7fd35569dde2ada8ec9116"
+checksum = "0be7b2ac146c1f99fe245c02d16af0696450d8e06c135db75e10eeb9e642c20d"
 dependencies = [
- "base64 0.13.1",
+ "base64 0.21.2",
  "bytes",
  "ed25519-dalek",
  "hex",
@@ -543,6 +555,7 @@ dependencies = [
  "rand",
  "rlp",
  "serde",
+ "serde-hex",
  "sha3",
  "zeroize",
 ]
@@ -1053,6 +1066,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "maybe-uninit"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
+
+[[package]]
 name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1089,6 +1108,12 @@ name = "more-asserts"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7843ec2de400bcbc6a6328c958dc38e5359da6e93e72e37bc5246bf1ae776389"
+
+[[package]]
+name = "nodrop"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
 
 [[package]]
 name = "nu-ansi-term"
@@ -1173,7 +1198,7 @@ dependencies = [
  "instant",
  "libc",
  "redox_syscall",
- "smallvec",
+ "smallvec 1.10.0",
  "winapi",
 ]
 
@@ -1468,6 +1493,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-hex"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca37e3e4d1b39afd7ff11ee4e947efae85adfddf4841787bfa47c470e96dc26d"
+dependencies = [
+ "array-init",
+ "serde",
+ "smallvec 0.6.14",
+]
+
+[[package]]
 name = "serde_derive"
 version = "1.0.175"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1594,6 +1630,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6528351c9bc8ab22353f9d776db39a20288e8d6c37ef8cfe3317cf875eecfc2d"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "smallvec"
+version = "0.6.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97fcaeba89edba30f044a10c6a3cc39df9c3f17d7cd829dd1446cab35f890e0"
+dependencies = [
+ "maybe-uninit",
 ]
 
 [[package]]
@@ -1880,7 +1925,7 @@ dependencies = [
  "once_cell",
  "regex",
  "sharded-slab",
- "smallvec",
+ "smallvec 1.10.0",
  "thread_local",
  "tracing",
  "tracing-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -419,7 +419,7 @@ dependencies = [
 [[package]]
 name = "discv5"
 version = "0.3.0"
-source = "git+https://github.com/ackintosh/discv5.git?rev=5e4503f6d05e6f5be9b091bc8bb2032630be2e9f#5e4503f6d05e6f5be9b091bc8bb2032630be2e9f"
+source = "git+https://github.com/ackintosh/discv5.git?rev=7e680c1c297192fe1aa218814e19451622a6b415#7e680c1c297192fe1aa218814e19451622a6b415"
 dependencies = [
  "aes",
  "aes-gcm",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -428,7 +428,7 @@ dependencies = [
 [[package]]
 name = "discv5"
 version = "0.3.1"
-source = "git+https://github.com/ackintosh/discv5.git?rev=59f9ca11b923139da26db710d1144537001f04a5#59f9ca11b923139da26db710d1144537001f04a5"
+source = "git+https://github.com/ackintosh/discv5.git?rev=90bcd002c3ef711b1558c4a6989e4b65f7737718#90bcd002c3ef711b1558c4a6989e4b65f7737718"
 dependencies = [
  "aes",
  "aes-gcm",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -428,7 +428,7 @@ dependencies = [
 [[package]]
 name = "discv5"
 version = "0.3.1"
-source = "git+https://github.com/ackintosh/discv5.git?rev=337be4b135cd8ddd71a081d37bcba19c8cfe6342#337be4b135cd8ddd71a081d37bcba19c8cfe6342"
+source = "git+https://github.com/ackintosh/discv5.git?rev=59f9ca11b923139da26db710d1144537001f04a5#59f9ca11b923139da26db710d1144537001f04a5"
 dependencies = [
  "aes",
  "aes-gcm",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -428,7 +428,7 @@ dependencies = [
 [[package]]
 name = "discv5"
 version = "0.3.1"
-source = "git+https://github.com/njgheorghita/discv5.git?rev=32b2240a8f6466969aec3215abf62db9edfadb13#32b2240a8f6466969aec3215abf62db9edfadb13"
+source = "git+https://github.com/njgheorghita/discv5.git?rev=09262ead2882e062de1a6a45df9ea61917eb8465#09262ead2882e062de1a6a45df9ea61917eb8465"
 dependencies = [
  "aes",
  "aes-gcm",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -419,7 +419,7 @@ dependencies = [
 [[package]]
 name = "discv5"
 version = "0.3.0"
-source = "git+https://github.com/ackintosh/discv5.git?rev=7e680c1c297192fe1aa218814e19451622a6b415#7e680c1c297192fe1aa218814e19451622a6b415"
+source = "git+https://github.com/ackintosh/discv5.git?rev=99452cd550944a352e7047f329b097d3cfb04e4b#99452cd550944a352e7047f329b097d3cfb04e4b"
 dependencies = [
  "aes",
  "aes-gcm",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,6 +81,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
 
 [[package]]
+name = "alloy-rlp"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d58d9f5da7b40e9bfff0b7e7816700be4019db97d4b6359fe7f94a9e22e42ac"
+dependencies = [
+ "arrayvec",
+ "bytes",
+]
+
+[[package]]
 name = "android-tzdata"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -425,11 +435,11 @@ dependencies = [
 [[package]]
 name = "discv5"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63b0b31b65aa1fcbd4e0171f1afed5363ccf25efb988ecd42450036f4c6d8539"
+source = "git+https://github.com/armaganyildirak/discv5.git?rev=f86b64af16bfb74c9252e454d2bd52571e0b69d3#f86b64af16bfb74c9252e454d2bd52571e0b69d3"
 dependencies = [
  "aes",
  "aes-gcm",
+ "alloy-rlp",
  "arrayvec",
  "delay_map",
  "enr 0.10.0",
@@ -443,12 +453,10 @@ dependencies = [
  "more-asserts",
  "parking_lot",
  "rand",
- "rlp",
  "smallvec",
  "socket2 0.4.9",
  "tokio",
  "tracing",
- "tracing-subscriber",
  "uint",
  "zeroize",
 ]
@@ -563,9 +571,9 @@ dependencies = [
 [[package]]
 name = "enr"
 version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a3d8dc56e02f954cac8eb489772c552c473346fc34f67412bb6244fd647f7e4"
+source = "git+https://github.com/sigp/enr?rev=77bde01922fb0b79b0c12bdecc1511b324e8f06c#77bde01922fb0b79b0c12bdecc1511b324e8f06c"
 dependencies = [
+ "alloy-rlp",
  "base64 0.21.2",
  "bytes",
  "ed25519-dalek",
@@ -573,7 +581,6 @@ dependencies = [
  "k256",
  "log",
  "rand",
- "rlp",
  "serde",
  "sha3",
  "zeroize",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,8 @@ path = "src/main.rs"
 chrono = "0.4.26"
 # Speed up ENR update
 # https://github.com/sigp/discv5/commit/a9ded0490229418cb61e747d55d3e0879b62e1d7
-#discv5 = { git = "https://github.com/njgheorghita/discv5.git", rev = "6bece1362378b839032cf8f6accd6a28a78814e3" }
-discv5 = { git = "https://github.com/ackintosh/discv5.git", rev = "5e4503f6d05e6f5be9b091bc8bb2032630be2e9f" }
+discv5 = { git = "https://github.com/njgheorghita/discv5.git", rev = "786104dca52be768d085e6bc867797cf45c0b140" }
+#discv5 = { git = "https://github.com/ackintosh/discv5.git", rev = "258822ca9b2c2ac1f7d403cb98423a31f17918de" }
 rand_xorshift = "0.3.0"
 serde = "1.0.175"
 serde_json = "1.0.104"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,15 @@ name = "discv5-testground"
 path = "src/main.rs"
 
 [dependencies]
-discv5 = "0.4.0"
+#discv5 = "0.4.0"
+
+# Change rlp to alloy-rlp
+# https://github.com/sigp/discv5/pull/212
+discv5 = { git = "https://github.com/armaganyildirak/discv5.git", rev = "f86b64af16bfb74c9252e454d2bd52571e0b69d3" }
+
+# Merge master into discv5.2
+# https://github.com/sigp/discv5/pull/234
+#discv5 = { git = "https://github.com/ackintosh/discv5.git", rev = "c58677e387f27bd075b671ea5d5410a64ffd9bb4"}
 
 chrono = "0.4.31"
 rand_xorshift = "0.3.0"
@@ -20,7 +28,7 @@ testground = "0.4.0"
 tokio = { version = "1.34.0", features = ["macros"] }
 tokio-stream = "0.1.14"
 tracing = "0.1.40"
-tracing-subscriber = "0.3.18"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 # *** mock *** ################################################################
 aes-gcm = "0.9.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,9 @@ path = "src/main.rs"
 chrono = "0.4.26"
 # Speed up ENR update
 # https://github.com/sigp/discv5/commit/a9ded0490229418cb61e747d55d3e0879b62e1d7
-#discv5 = { git = "https://github.com/njgheorghita/discv5.git", rev = "09262ead2882e062de1a6a45df9ea61917eb8465" }
-discv5 = { git = "https://github.com/ackintosh/discv5.git", rev = "59f9ca11b923139da26db710d1144537001f04a5" }
+#discv5 = { git = "https://github.com/njgheorghita/discv5.git", rev = "5e05a7d442c1ce621e53e5eba3d4842c70ed3c4d" }
+discv5 = { git = "https://github.com/ackintosh/discv5.git", rev = "57226fe83af5b9a45c277fae7581718c92cd4336" }
+#discv5 = { git = "https://github.com/sigp/discv5.git", rev = "faa58014ce658d5b4d186a8dba9fc191de76a0c1" }
 rand_xorshift = "0.3.0"
 serde = "1.0.175"
 serde_json = "1.0.104"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,9 @@ tracing = "0.1.37"
 tracing-subscriber = "0.3.17"
 
 # *** mock ***
+aes-gcm = "0.9.4"
 rand = "0.8.5"
 zeroize = { version = "1.4.3", features = ["zeroize_derive"] }
 # This version must be kept up to date do it uses the same dependencies as ENR
 hkdf = "0.12.3"
+enr = { version = "0.9.0", features = ["k256", "ed25519"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,8 @@ path = "src/main.rs"
 chrono = "0.4.26"
 # Speed up ENR update
 # https://github.com/sigp/discv5/commit/a9ded0490229418cb61e747d55d3e0879b62e1d7
-discv5 = { git = "https://github.com/njgheorghita/discv5.git", rev = "786104dca52be768d085e6bc867797cf45c0b140" }
-#discv5 = { git = "https://github.com/ackintosh/discv5.git", rev = "258822ca9b2c2ac1f7d403cb98423a31f17918de" }
+#discv5 = { git = "https://github.com/njgheorghita/discv5.git", rev = "786104dca52be768d085e6bc867797cf45c0b140" }
+discv5 = { git = "https://github.com/ackintosh/discv5.git", rev = "730db0976edcf91a0d3736ca168b358844c9cbe2" }
 rand_xorshift = "0.3.0"
 serde = "1.0.175"
 serde_json = "1.0.104"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ chrono = "0.4.26"
 # Speed up ENR update
 # https://github.com/sigp/discv5/commit/a9ded0490229418cb61e747d55d3e0879b62e1d7
 #discv5 = { git = "https://github.com/njgheorghita/discv5.git", rev = "09262ead2882e062de1a6a45df9ea61917eb8465" }
-discv5 = { git = "https://github.com/ackintosh/discv5.git", rev = "337be4b135cd8ddd71a081d37bcba19c8cfe6342" }
+discv5 = { git = "https://github.com/ackintosh/discv5.git", rev = "59f9ca11b923139da26db710d1144537001f04a5" }
 rand_xorshift = "0.3.0"
 serde = "1.0.175"
 serde_json = "1.0.104"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,11 +11,9 @@ path = "src/main.rs"
 
 [dependencies]
 chrono = "0.4.26"
-# Speed up ENR update
-# https://github.com/sigp/discv5/commit/a9ded0490229418cb61e747d55d3e0879b62e1d7
-#discv5 = { git = "https://github.com/njgheorghita/discv5.git", rev = "5e05a7d442c1ce621e53e5eba3d4842c70ed3c4d" }
-discv5 = { git = "https://github.com/ackintosh/discv5.git", rev = "57226fe83af5b9a45c277fae7581718c92cd4336" }
-#discv5 = { git = "https://github.com/sigp/discv5.git", rev = "faa58014ce658d5b4d186a8dba9fc191de76a0c1" }
+
+discv5 = { git = "https://github.com/ackintosh/discv5.git", rev = "e6df09a0f32000ae5618d5f2f84413817df3b6e1" }
+
 rand_xorshift = "0.3.0"
 serde = "1.0.175"
 serde_json = "1.0.104"
@@ -25,10 +23,11 @@ tokio-stream = "0.1.14"
 tracing = "0.1.37"
 tracing-subscriber = "0.3.17"
 
-# *** mock ***
+# *** mock *** ################################################################
 aes-gcm = "0.9.4"
 rand = "0.8.5"
 zeroize = { version = "1.4.3", features = ["zeroize_derive"] }
 # This version must be kept up to date do it uses the same dependencies as ENR
 hkdf = "0.12.3"
 enr = { version = "0.9.0", features = ["k256", "ed25519"] }
+# #############################################################################

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,10 +10,9 @@ name = "discv5-testground"
 path = "src/main.rs"
 
 [dependencies]
+discv5 = "0.4.0"
+
 chrono = "0.4.31"
-
-discv5 = { git = "https://github.com/ackintosh/discv5.git", rev = "e6df09a0f32000ae5618d5f2f84413817df3b6e1" }
-
 rand_xorshift = "0.3.0"
 serde = "1.0.193"
 serde_json = "1.0.108"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,8 @@ path = "src/main.rs"
 chrono = "0.4.26"
 # Speed up ENR update
 # https://github.com/sigp/discv5/commit/a9ded0490229418cb61e747d55d3e0879b62e1d7
-discv5 = { git = "https://github.com/sigp/discv5.git", rev = "a9ded0490229418cb61e747d55d3e0879b62e1d7" }
+#discv5 = { git = "https://github.com/njgheorghita/discv5.git", rev = "6bece1362378b839032cf8f6accd6a28a78814e3" }
+discv5 = { git = "https://github.com/ackintosh/discv5.git", rev = "5e4503f6d05e6f5be9b091bc8bb2032630be2e9f" }
 rand_xorshift = "0.3.0"
 serde = "1.0.175"
 serde_json = "1.0.104"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,8 @@ path = "src/main.rs"
 chrono = "0.4.26"
 # Speed up ENR update
 # https://github.com/sigp/discv5/commit/a9ded0490229418cb61e747d55d3e0879b62e1d7
-#discv5 = { git = "https://github.com/njgheorghita/discv5.git", rev = "786104dca52be768d085e6bc867797cf45c0b140" }
-discv5 = { git = "https://github.com/ackintosh/discv5.git", rev = "730db0976edcf91a0d3736ca168b358844c9cbe2" }
+discv5 = { git = "https://github.com/njgheorghita/discv5.git", rev = "32b2240a8f6466969aec3215abf62db9edfadb13" }
+#discv5 = { git = "https://github.com/ackintosh/discv5.git", rev = "18892eff6f90d0fb4ac10878999d88492f4f3efc" }
 rand_xorshift = "0.3.0"
 serde = "1.0.175"
 serde_json = "1.0.104"
@@ -23,3 +23,9 @@ tokio = { version = "1.29.0", features = ["macros"] }
 tokio-stream = "0.1.14"
 tracing = "0.1.37"
 tracing-subscriber = "0.3.17"
+
+# *** mock ***
+rand = "0.8.5"
+zeroize = { version = "1.4.3", features = ["zeroize_derive"] }
+# This version must be kept up to date do it uses the same dependencies as ENR
+hkdf = "0.12.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,8 @@ path = "src/main.rs"
 chrono = "0.4.26"
 # Speed up ENR update
 # https://github.com/sigp/discv5/commit/a9ded0490229418cb61e747d55d3e0879b62e1d7
-discv5 = { git = "https://github.com/njgheorghita/discv5.git", rev = "09262ead2882e062de1a6a45df9ea61917eb8465" }
-#discv5 = { git = "https://github.com/ackintosh/discv5.git", rev = "54c28037368ffb8cfa381e6ea089f7988694a806" }
+#discv5 = { git = "https://github.com/njgheorghita/discv5.git", rev = "09262ead2882e062de1a6a45df9ea61917eb8465" }
+discv5 = { git = "https://github.com/ackintosh/discv5.git", rev = "337be4b135cd8ddd71a081d37bcba19c8cfe6342" }
 rand_xorshift = "0.3.0"
 serde = "1.0.175"
 serde_json = "1.0.104"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,8 @@ path = "src/main.rs"
 chrono = "0.4.26"
 # Speed up ENR update
 # https://github.com/sigp/discv5/commit/a9ded0490229418cb61e747d55d3e0879b62e1d7
-discv5 = { git = "https://github.com/njgheorghita/discv5.git", rev = "32b2240a8f6466969aec3215abf62db9edfadb13" }
-#discv5 = { git = "https://github.com/ackintosh/discv5.git", rev = "18892eff6f90d0fb4ac10878999d88492f4f3efc" }
+discv5 = { git = "https://github.com/njgheorghita/discv5.git", rev = "09262ead2882e062de1a6a45df9ea61917eb8465" }
+#discv5 = { git = "https://github.com/ackintosh/discv5.git", rev = "54c28037368ffb8cfa381e6ea089f7988694a806" }
 rand_xorshift = "0.3.0"
 serde = "1.0.175"
 serde_json = "1.0.104"

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN mkdir -p ./plan/src/
 RUN echo "fn main() { println!(\"If you see this message, you may want to clean up the target directory or the Docker build cache.\") }" > ./plan/src/main.rs
 COPY ./plan/Cargo.lock ./plan/
 COPY ./plan/Cargo.toml ./plan/
-RUN cd ./plan/ && cargo build --release
+RUN cd ./plan/ && cargo build
 
 COPY . .
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,6 @@ RUN cd plan && cargo install --locked --path .
 FROM debian:bullseye-slim
 COPY --from=builder /usr/local/cargo/bin/discv5-testground /usr/local/bin/discv5-testground
 
-ENV RUST_LOG=discv5=debug
+ENV RUST_LOG=discv5=trace
 
 ENTRYPOINT ["discv5-testground"]

--- a/README.md
+++ b/README.md
@@ -303,7 +303,7 @@ testground run single \
   --wait
 ```
 
-### [`sandbox`](#sandbox)
+### [`sandbox`](#test-cases)
 
 This is a special test plan where the test flow is undefined, used for experiments to debug.
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ testground run single \
 - [eclipse-attack-monopolizing-by-incoming-nodes](#eclipse-attack-monopolizing-by-incoming-nodes)
 - [enr-update](#enr-update)
 - [ip-change](#ip-change)
+- [talk](#talk)
 
 ### [`find-node`](#test-cases)
 
@@ -146,6 +147,20 @@ sequenceDiagram
     Node1 ->> Node2 ... Node N: PING
     Node2 ... Node N ->> Node1: PING
     end
+```
+
+### [`talk`](#test-cases)
+
+This test plan runs simple TALKREQ/TALKRESP communication between two nodes.
+
+```shell
+testground run single \
+  --plan=discv5-testground \
+  --testcase=talk \
+  --builder=docker:generic \
+  --runner=local:docker \
+  --instances=2 \
+  --wait
 ```
 
 ## Metrics

--- a/README.md
+++ b/README.md
@@ -27,7 +27,11 @@ testground run single \
 - [eclipse-attack-monopolizing-by-incoming-nodes](#eclipse-attack-monopolizing-by-incoming-nodes)
 - [enr-update](#enr-update)
 - [ip-change](#ip-change)
+- [concurrent-requests](#concurrent-requests)
+- [concurrent-requests_whoareyou-timeout](#concurrent-requests_whoareyou-timeout)
+- [concurrent-requests_before-establishing-session](#concurrent-requests_before-establishing-session)
 - [talk](#talk)
+- [sandbox](#sandbox)
 
 ### [`find-node`](#test-cases)
 
@@ -149,6 +153,142 @@ sequenceDiagram
     end
 ```
 
+### [`concurrent-requests`](#test-cases)
+
+```shell
+testground run single \
+  --plan=discv5-testground \
+  --testcase=concurrent-requests \
+  --builder=docker:generic \
+  --runner=local:docker \
+  --instances=2 \
+  --wait
+```
+
+```mermaid
+sequenceDiagram
+    participant Node1
+    participant Node2
+    Note over Node1: Start discv5 server
+    Note over Node2: Start discv5 server
+
+    rect rgb(10, 10, 10)
+    Note left of Node1: They communicate with each other<br> to establish a session.
+    Node1 ->> Node2: message
+    Node2 ->> Node1: message
+    Note over Node1,Node2: Session established
+    end
+
+    rect rgb(100, 100, 0)
+    Note right of Node2: In this test case, Node2 session timeout <br>is set to short term (a few seconds)<br> to reproduce session expiration.
+    Note over Node2: Session expired
+    end
+
+    rect rgb(10, 10, 10)
+    Note left of Node1: Node1 sends multiple requests<br> **in parallel**.
+    par 
+    Node1 ->> Node2: FINDNODE
+    and 
+    Node1 ->> Node2: FINDNODE
+    end
+    end
+```
+
+### [`concurrent-requests_whoareyou-timeout`](#test-cases)
+
+A test case where WHOAREYOU packet times out.
+
+```shell
+testground run single \
+  --plan=discv5-testground \
+  --testcase=concurrent-requests_whoareyou-timeout \
+  --builder=docker:generic \
+  --runner=local:docker \
+  --instances=2 \
+  --wait
+```
+
+```mermaid
+sequenceDiagram
+    participant Node1
+    participant Node2
+
+    Node2 ->> Node1: Random packet
+    Node1 ->> Node2: WHOAREYOU
+    rect rgb(100, 100, 0)
+    Note over Node2: ** Discard the WHOAREYOU packet<br>to reproduce kind of network issue. **
+    end
+
+    rect rgb(10, 10, 10)
+    Note left of Node1: Node1 want to send FINDNODE to Node2<br>but active_challenge exists.<br>So insert requests into pending_requests.
+    par 
+    Note over Node1: pending_requests.insert()
+    and 
+    Note over Node1: pending_requests.insert()
+    end
+    end
+
+    rect rgb(100, 100, 0)
+    Note over Node1: The challenge in active_challenges<br>has been expired.
+    end
+```
+
+### [`concurrent-requests_before-establishing-session`](#test-cases)
+
+A test case where a node attempts to send requests in parallel before establishing a session.
+
+```shell
+testground run single \
+  --plan=discv5-testground \
+  --testcase=concurrent-requests_before-establishing-session \
+  --builder=docker:generic \
+  --runner=local:docker \
+  --instances=2 \
+  --wait
+```
+
+```mermaid
+sequenceDiagram
+    participant Node1
+    participant Node2
+
+    Note over Node1: No session with Node2
+
+    rect rgb(10, 10, 10)
+    Note left of Node1: Node1 attempts to send multiple requests in parallel <br> but no session with Node2.<br> So Node1 sends a random packet for the first request, <br>and the rest of the requests are inserted into pending_requests.
+    par
+    Node1 ->> Node2: Random packet (id:1)
+    Note over Node1: Insert the request into `active_requests`
+    and
+    Note over Node1: Insert Request(id:2) into *pending_requests*
+    and
+    Note over Node1: Insert Request(id:3) into *pending_requests*
+    end
+    end
+
+    Node2 ->> Node1: WHOAREYOU (id:1)
+
+    Note over Node1: New session established with Node2
+
+    rect rgb(0, 100, 0)
+    Note over Node1: Send pending requests since a session has been established.
+    Node1 ->> Node2: Request (id:2)
+    Node1 ->> Node2: Request (id:3)
+    end
+
+    Node1 ->> Node2: Handshake message (id:1)
+
+    Note over Node2: New session established with Node1
+
+    Node2 ->> Node1: Response (id:2)
+    Node2 ->> Node1: Response (id:3)
+    Node2 ->> Node1: Response (id:1)
+
+    Note over Node1: The request (id:2) completed.
+    Note over Node1: The request (id:3) completed.
+    Note over Node1: The request (id:1) completed.
+```
+
 ### [`talk`](#test-cases)
 
 This test plan runs simple TALKREQ/TALKRESP communication between two nodes.
@@ -157,6 +297,20 @@ This test plan runs simple TALKREQ/TALKRESP communication between two nodes.
 testground run single \
   --plan=discv5-testground \
   --testcase=talk \
+  --builder=docker:generic \
+  --runner=local:docker \
+  --instances=2 \
+  --wait
+```
+
+### [`sandbox`](#sandbox)
+
+This is a special test plan where the test flow is undefined, used for experiments to debug.
+
+```shell
+testground run single \
+  --plan=discv5-testground \
+  --testcase=sandbox \
   --builder=docker:generic \
   --runner=local:docker \
   --instances=2 \

--- a/manifest.toml
+++ b/manifest.toml
@@ -31,13 +31,22 @@ instances = { min = 20, max = 20, default = 20 }
   # Params for the `victim` group
   incoming_bucket_limit = { type = "int", desc = "A maximum limit to the number of incoming nodes per bucket.", default = 16 }
 
+# #############################################################################
 # Concurrent requests
+# #############################################################################
 [[testcases]]
 name = "concurrent-requests"
 instances = { min = 2, max = 2, default = 2 }
 
   [testcases.params]
   latency = { type = "int", desc = "Latency between peers.", unit = "ms", default = 100 }
+
+[[testcases]]
+name = "concurrent-requests_whoareyou-timeout"
+instances = { min = 2, max = 2, default = 2 }
+
+[testcases.params]
+latency = { type = "int", desc = "Latency between peers.", unit = "ms", default = 100 }
 
 # IP change
 [[testcases]]

--- a/manifest.toml
+++ b/manifest.toml
@@ -10,7 +10,9 @@ enabled = true
 [runners."local:docker"]
 enabled = true
 
+# #############################################################################
 # FINDNODE
+# #############################################################################
 [[testcases]]
 name = "find-node"
 instances = { min = 3, max = 100, default = 3 }
@@ -18,7 +20,9 @@ instances = { min = 3, max = 100, default = 3 }
   [testcases.params]
   latency = { type = "int", desc = "Latency between peers.", unit = "ms", default = 100 }
 
+# #############################################################################
 # Eclipse attack by monopolizing by incoming nodes
+# #############################################################################
 [[testcases]]
 name = "eclipse-attack-monopolizing-by-incoming-nodes"
 # The number of `instances` is fixed to 20 in this test case. For more detail,
@@ -41,14 +45,25 @@ instances = { min = 2, max = 2, default = 2 }
   [testcases.params]
   latency = { type = "int", desc = "Latency between peers.", unit = "ms", default = 100 }
 
+# A test case where WHOAREYOU packet times out.
 [[testcases]]
 name = "concurrent-requests_whoareyou-timeout"
 instances = { min = 2, max = 2, default = 2 }
 
-[testcases.params]
-latency = { type = "int", desc = "Latency between peers.", unit = "ms", default = 100 }
+  [testcases.params]
+  latency = { type = "int", desc = "Latency between peers.", unit = "ms", default = 100 }
 
+# A test case where a node attempts to send requests in parallel before establishing a session.
+[[testcases]]
+name = "concurrent-requests_before-establishing-session"
+instances = { min = 2, max = 2, default = 2 }
+
+  [testcases.params]
+  latency = { type = "int", desc = "Latency between peers.", unit = "ms", default = 100 }
+
+# #############################################################################
 # IP change
+# #############################################################################
 [[testcases]]
 name = "ip-change"
 instances = { min = 3, max = 100, default = 3 }
@@ -64,7 +79,9 @@ instances = { min = 3, max = 100, default = 3 }
   duration_before = { type = "int", desc = "Duration to run the simulation before changing IP address.", default = 5, unit="sec" }
   duration_after = { type = "int", desc = "Duration to run the simulation after changing IP address.", default = 15, unit="sec" }
 
+# #############################################################################
 # ENR update
+# #############################################################################
 [[testcases]]
 name = "enr-update"
 instances = { min = 11, max = 100, default = 11 }

--- a/manifest.toml
+++ b/manifest.toml
@@ -91,3 +91,13 @@ instances = { min = 11, max = 100, default = 11 }
 
   # discv5 params
   ping_interval = { type = "int", desc = "The time between pings.", unit = "sec", default = 30 }
+
+# #############################################################################
+# Sandbox
+# #############################################################################
+[[testcases]]
+name = "sandbox"
+instances = { min = 2, max = 2, default = 2 }
+
+[testcases.params]
+latency = { type = "int", desc = "Latency between peers.", unit = "ms", default = 100 }

--- a/manifest.toml
+++ b/manifest.toml
@@ -34,7 +34,7 @@ instances = { min = 20, max = 20, default = 20 }
 # Concurrent requests
 [[testcases]]
 name = "concurrent-requests"
-instances = { min = 2, max = 100, default = 2 }
+instances = { min = 2, max = 2, default = 2 }
 
   [testcases.params]
   latency = { type = "int", desc = "Latency between peers.", unit = "ms", default = 100 }

--- a/manifest.toml
+++ b/manifest.toml
@@ -97,7 +97,7 @@ instances = { min = 11, max = 100, default = 11 }
 # #############################################################################
 [[testcases]]
 name = "sandbox"
-instances = { min = 2, max = 2, default = 2 }
+instances = { min = 2, max = 3, default = 2 }
 
 [testcases.params]
 latency = { type = "int", desc = "Latency between peers.", unit = "ms", default = 100 }

--- a/manifest.toml
+++ b/manifest.toml
@@ -31,6 +31,14 @@ instances = { min = 20, max = 20, default = 20 }
   # Params for the `victim` group
   incoming_bucket_limit = { type = "int", desc = "A maximum limit to the number of incoming nodes per bucket.", default = 16 }
 
+# Concurrent requests
+[[testcases]]
+name = "concurrent-requests"
+instances = { min = 2, max = 100, default = 2 }
+
+  [testcases.params]
+  latency = { type = "int", desc = "Latency between peers.", unit = "ms", default = 100 }
+
 # IP change
 [[testcases]]
 name = "ip-change"

--- a/manifest.toml
+++ b/manifest.toml
@@ -101,3 +101,13 @@ instances = { min = 2, max = 3, default = 2 }
 
 [testcases.params]
 latency = { type = "int", desc = "Latency between peers.", unit = "ms", default = 100 }
+
+# #############################################################################
+# Talk
+# #############################################################################
+[[testcases]]
+name = "talk"
+instances = { min = 2, max = 2, default = 2 }
+
+[testcases.params]
+latency = { type = "int", desc = "Latency between peers.", unit = "ms", default = 100 }

--- a/src/concurrent_requests/before_establishing_session.rs
+++ b/src/concurrent_requests/before_establishing_session.rs
@@ -1,7 +1,7 @@
 use crate::concurrent_requests::InstanceInfo;
 use crate::utils::publish_and_collect;
-use discv5::enr::{CombinedKey, EnrBuilder};
-use discv5::{Discv5, ListenConfig};
+use discv5::enr::CombinedKey;
+use discv5::{Discv5, Enr, ListenConfig};
 use std::net::Ipv4Addr;
 use std::time::Duration;
 use testground::client::Client;
@@ -20,7 +20,7 @@ pub(crate) async fn run(client: Client) -> Result<(), Box<dyn std::error::Error>
     // Construct local Enr
     // ////////////////////////
     let enr_key = CombinedKey::generate_secp256k1();
-    let enr = EnrBuilder::new("v4")
+    let enr = Enr::builder()
         .ip(ip)
         .udp4(9000)
         .build(&enr_key)

--- a/src/concurrent_requests/before_establishing_session.rs
+++ b/src/concurrent_requests/before_establishing_session.rs
@@ -126,5 +126,6 @@ pub(crate) async fn run(client: Client) -> Result<(), Box<dyn std::error::Error>
         .signal_and_wait(STATE_FINISHED, client.run_parameters().test_instance_count)
         .await?;
 
+    client.record_success().await?;
     Ok(())
 }

--- a/src/concurrent_requests/before_establishing_session.rs
+++ b/src/concurrent_requests/before_establishing_session.rs
@@ -1,11 +1,10 @@
 use crate::concurrent_requests::InstanceInfo;
 use crate::utils::publish_and_collect;
 use discv5::enr::{CombinedKey, EnrBuilder};
-use discv5::{Discv5, ListenConfig, RequestError};
+use discv5::{Discv5, ListenConfig};
 use std::net::Ipv4Addr;
 use std::time::Duration;
 use testground::client::Client;
-use tokio::sync::mpsc::Receiver;
 use tracing::{error, info};
 
 const STATE_DISCV5_STARTED: &str = "state_discv5_started";
@@ -104,7 +103,7 @@ pub(crate) async fn run(client: Client) -> Result<(), Box<dyn std::error::Error>
                     discv5::Event::NodeInserted { .. } => {}
                     discv5::Event::SessionEstablished(_, _) => {}
                     discv5::Event::SocketUpdated(_) => {}
-                    discv5::Event::TalkRequest(mut req) => {
+                    discv5::Event::TalkRequest(req) => {
                         req_count += 1;
                         info!("TalkRequest: {:?}", req);
                         let response = req.body().to_vec();

--- a/src/concurrent_requests/before_establishing_session.rs
+++ b/src/concurrent_requests/before_establishing_session.rs
@@ -1,0 +1,130 @@
+use std::net::Ipv4Addr;
+use std::time::Duration;
+use discv5::enr::{CombinedKey, EnrBuilder};
+use discv5::{Discv5, ListenConfig, RequestError};
+use testground::client::Client;
+use tokio::sync::mpsc::Receiver;
+use tracing::{error, info};
+use crate::concurrent_requests::InstanceInfo;
+use crate::utils::publish_and_collect;
+
+const STATE_DISCV5_STARTED: &str = "state_discv5_started";
+const STATE_FINISHED: &str = "state_finished";
+
+pub(crate) async fn run(client: Client) -> Result<(), Box<dyn std::error::Error>> {
+    let run_parameters = client.run_parameters();
+    let ip = run_parameters
+        .data_network_ip()?
+        .expect("IP address for the data network");
+
+    // ////////////////////////
+    // Construct local Enr
+    // ////////////////////////
+    let enr_key = CombinedKey::generate_secp256k1();
+    let enr = EnrBuilder::new("v4")
+        .ip(ip)
+        .udp4(9000)
+        .build(&enr_key)
+        .expect("enr");
+
+    // //////////////////////////////////////////////////////////////
+    // Collect information of all participants in the test case
+    // //////////////////////////////////////////////////////////////
+    let instance_info = InstanceInfo {
+        seq: client.global_seq(),
+        enr: enr.clone(),
+    };
+    client.record_message(format!(
+        "seq: {}, node_id: {}, ip: {}",
+        instance_info.seq,
+        instance_info.enr.node_id(),
+        ip
+    ));
+
+    let another_instance_info = {
+        let participants = publish_and_collect(&client, instance_info).await?;
+        assert_eq!(2, participants.len());
+
+        let info = participants
+            .into_iter()
+            .filter(|p| p.seq != client.global_seq())
+            .collect::<Vec<_>>();
+        assert!(!info.is_empty());
+
+        info.first().unwrap().clone()
+    };
+
+    // ////////////////////////
+    // Discv5 config
+    // ////////////////////////
+    let listen_config = ListenConfig::Ipv4 {
+        ip: Ipv4Addr::UNSPECIFIED,
+        port: 9000,
+    };
+    let config = discv5::ConfigBuilder::new(listen_config)
+        .request_timeout(Duration::from_secs(5))
+        .build();
+
+    // ////////////////////////
+    // Start discv5
+    // ////////////////////////
+    let mut discv5: Discv5 = Discv5::new(enr.clone(), enr_key, config)?;
+    discv5.start().await.expect("Start Discovery v5 server");
+
+    client
+        .signal_and_wait(
+            STATE_DISCV5_STARTED,
+            client.run_parameters().test_instance_count,
+        )
+        .await?;
+
+    match client.global_seq() {
+        1 => {
+            // Sent requests in parallel.
+            let mut handles = vec![];
+            for i in 0..2 {
+                let fut = discv5.talk_req(another_instance_info.enr.clone(), vec![0], vec![i]);
+                handles.push(tokio::spawn(fut));
+            }
+
+            for h in handles {
+                match h.await.unwrap() {
+                    Ok(res) => info!("Response: {:?}", res),
+                    Err(e) => error!("Request failed: {e}"),
+                }
+            }
+        }
+        2 => {
+            let mut req_count = 0;
+            let mut event = discv5.event_stream().await.expect("event stream");
+            while let Some(ev) = event.recv().await {
+                match ev {
+                    discv5::Event::Discovered(_) => {}
+                    discv5::Event::EnrAdded { .. } => {}
+                    discv5::Event::NodeInserted { .. } => {}
+                    discv5::Event::SessionEstablished(_, _) => {}
+                    discv5::Event::SocketUpdated(_) => {}
+                    discv5::Event::TalkRequest(mut req) => {
+                        req_count += 1;
+                        info!("TalkRequest: {:?}", req);
+                        let response = req.body().to_vec();
+                        if let Err(e) = req.respond(response) {
+                            error!("Failed to send response: {:?}", e);
+                        }
+
+                        if req_count == 2 {
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+        _ => unreachable!(),
+    }
+
+    client
+        .signal_and_wait(STATE_FINISHED, client.run_parameters().test_instance_count)
+        .await?;
+
+    Ok(())
+}

--- a/src/concurrent_requests/mod.rs
+++ b/src/concurrent_requests/mod.rs
@@ -118,7 +118,7 @@ pub(crate) async fn run(client: Client) -> Result<(), Box<dyn std::error::Error>
             let mut handles = vec![];
             for _ in 0..2 {
                 let fut = discv5.find_node_designated_peer(p.enr.clone(), vec![0]);
-                handles.push(tokio::spawn(async { fut.await }));
+                handles.push(tokio::spawn(fut));
             }
 
             for h in handles {

--- a/src/concurrent_requests/mod.rs
+++ b/src/concurrent_requests/mod.rs
@@ -1,5 +1,5 @@
-pub(crate) mod whoareyou_timeout;
 pub(crate) mod before_establishing_session;
+pub(crate) mod whoareyou_timeout;
 
 use crate::utils::publish_and_collect;
 use discv5::enr::{CombinedKey, EnrBuilder};

--- a/src/concurrent_requests/mod.rs
+++ b/src/concurrent_requests/mod.rs
@@ -1,0 +1,140 @@
+use crate::utils::publish_and_collect;
+use discv5::enr::{CombinedKey, EnrBuilder};
+use discv5::{Discv5, Discv5ConfigBuilder, Enr, ListenConfig};
+use serde::{Deserialize, Serialize};
+use std::net::Ipv4Addr;
+use std::time::Duration;
+use testground::client::Client;
+use tracing::error;
+
+const STATE_CONNECTED: &str = "state_connected";
+const STATE_COMPLETED: &str = "state_completed";
+
+// Session timeout for Node2 (in second).
+const SESSION_TIMEOUT_NODE2: u64 = 5;
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+struct InstanceInfo {
+    // The sequence number of this test instance within the test.
+    seq: u64,
+    enr: Enr,
+}
+
+pub(crate) async fn run(client: Client) -> Result<(), Box<dyn std::error::Error>> {
+    let run_parameters = client.run_parameters();
+    let ip = run_parameters
+        .data_network_ip()?
+        .expect("IP address for the data network");
+
+    // ////////////////////////
+    // Construct local Enr
+    // ////////////////////////
+    let enr_key = CombinedKey::generate_secp256k1();
+    let enr = EnrBuilder::new("v4")
+        .ip(ip)
+        .udp4(9000)
+        .build(&enr_key)
+        .expect("enr");
+
+    // ////////////////////////
+    // Start discv5
+    // ////////////////////////
+    let listen_config = ListenConfig::Ipv4 {
+        ip: Ipv4Addr::UNSPECIFIED,
+        port: 9000,
+    };
+
+    let config = if client.global_seq() == 2 {
+        Discv5ConfigBuilder::new(listen_config)
+            .session_timeout(Duration::from_secs(SESSION_TIMEOUT_NODE2))
+            .build()
+    } else {
+        Discv5ConfigBuilder::new(listen_config).build()
+    };
+
+    let mut discv5: Discv5 = Discv5::new(enr.clone(), enr_key, config)?;
+    discv5.start().await.expect("Start Discovery v5 server");
+
+    // //////////////////////////////////////////////////////////////
+    // Collect information of all participants in the test case
+    // //////////////////////////////////////////////////////////////
+    let instance_info = InstanceInfo {
+        seq: client.global_seq(),
+        enr,
+    };
+    client.record_message(format!(
+        "seq: {}, node_id: {}, ip: {}",
+        instance_info.seq,
+        instance_info.enr.node_id(),
+        ip
+    ));
+
+    let participants = publish_and_collect(&client, instance_info.clone()).await?;
+
+    // //////////////////////////////////////////////////////////////
+    // Construct topology
+    // //////////////////////////////////////////////////////////////
+    // Run FINDNODE query to connect to other participants.
+    if instance_info.seq == 1 {
+        for p in participants
+            .iter()
+            .filter(|&p| p.seq != client.global_seq())
+        {
+            let _ = discv5
+                .find_node_designated_peer(p.enr.clone(), vec![0])
+                .await;
+        }
+    }
+
+    client
+        .signal_and_wait(STATE_CONNECTED, run_parameters.test_instance_count)
+        .await?;
+
+    client.record_message(format!(
+        "peers: {:?}",
+        discv5
+            .kbuckets()
+            .iter()
+            .map(|b| (
+                b.node.value.ip4().unwrap(),
+                b.status.direction,
+                b.status.state
+            ))
+            .collect::<Vec<_>>()
+    ));
+
+    // //////////////////////////////////////////////////////////////
+    // Send requests in parallel
+    // //////////////////////////////////////////////////////////////
+    // Wait for the Node2 session to expire.
+    tokio::time::sleep(Duration::from_secs(SESSION_TIMEOUT_NODE2 + 2)).await;
+
+    // Send requests in parallel from Node1 to Node2.
+    if instance_info.seq == 1 {
+        for p in participants
+            .iter()
+            .filter(|&p| p.seq != client.global_seq())
+        {
+            let mut handles = vec![];
+            for _ in 0..2 {
+                let fut = discv5.find_node_designated_peer(p.enr.clone(), vec![0]);
+                handles.push(tokio::spawn(async { fut.await }));
+            }
+
+            for h in handles {
+                if let Err(e) = h.await {
+                    error!("Failed to join: {e}");
+                }
+            }
+        }
+    }
+
+    tokio::time::sleep(Duration::from_secs(3)).await;
+
+    client
+        .signal_and_wait(STATE_COMPLETED, run_parameters.test_instance_count)
+        .await?;
+
+    client.record_success().await?;
+    Ok(())
+}

--- a/src/concurrent_requests/mod.rs
+++ b/src/concurrent_requests/mod.rs
@@ -1,8 +1,9 @@
 pub(crate) mod whoareyou_timeout;
+pub(crate) mod before_establishing_session;
 
 use crate::utils::publish_and_collect;
 use discv5::enr::{CombinedKey, EnrBuilder};
-use discv5::{Discv5, Discv5ConfigBuilder, Enr, ListenConfig};
+use discv5::{Discv5, Enr, ListenConfig};
 use serde::{Deserialize, Serialize};
 use std::net::Ipv4Addr;
 use std::time::Duration;
@@ -47,11 +48,11 @@ pub(crate) async fn run(client: Client) -> Result<(), Box<dyn std::error::Error>
     };
 
     let config = if client.global_seq() == 2 {
-        Discv5ConfigBuilder::new(listen_config)
+        discv5::ConfigBuilder::new(listen_config)
             .session_timeout(Duration::from_secs(SESSION_TIMEOUT_NODE2))
             .build()
     } else {
-        Discv5ConfigBuilder::new(listen_config).build()
+        discv5::ConfigBuilder::new(listen_config).build()
     };
 
     let mut discv5: Discv5 = Discv5::new(enr.clone(), enr_key, config)?;

--- a/src/concurrent_requests/mod.rs
+++ b/src/concurrent_requests/mod.rs
@@ -1,3 +1,5 @@
+pub(crate) mod whoareyou_timeout;
+
 use crate::utils::publish_and_collect;
 use discv5::enr::{CombinedKey, EnrBuilder};
 use discv5::{Discv5, Discv5ConfigBuilder, Enr, ListenConfig};

--- a/src/concurrent_requests/mod.rs
+++ b/src/concurrent_requests/mod.rs
@@ -2,7 +2,7 @@ pub(crate) mod before_establishing_session;
 pub(crate) mod whoareyou_timeout;
 
 use crate::utils::publish_and_collect;
-use discv5::enr::{CombinedKey, EnrBuilder};
+use discv5::enr::CombinedKey;
 use discv5::{Discv5, Enr, ListenConfig};
 use serde::{Deserialize, Serialize};
 use std::net::Ipv4Addr;
@@ -33,7 +33,7 @@ pub(crate) async fn run(client: Client) -> Result<(), Box<dyn std::error::Error>
     // Construct local Enr
     // ////////////////////////
     let enr_key = CombinedKey::generate_secp256k1();
-    let enr = EnrBuilder::new("v4")
+    let enr = Enr::builder()
         .ip(ip)
         .udp4(9000)
         .build(&enr_key)

--- a/src/concurrent_requests/whoareyou_timeout.rs
+++ b/src/concurrent_requests/whoareyou_timeout.rs
@@ -138,7 +138,9 @@ async fn run_mock(
     let mut behaviours = VecDeque::new();
     behaviours.push_back(Behaviour {
         expect: Expect::WhoAreYou,
-        action: Action::Ignore("Ingore WHOAREYOU packet to make happen a challenge timeout on Node1 side.".to_string()),
+        action: Action::Ignore(
+            "Ingore WHOAREYOU packet to make happen a challenge timeout on Node1 side.".to_string(),
+        ),
     });
     behaviours.push_back(Behaviour {
         expect: Expect::MessageWithoutSession,

--- a/src/concurrent_requests/whoareyou_timeout.rs
+++ b/src/concurrent_requests/whoareyou_timeout.rs
@@ -151,7 +151,7 @@ async fn run_mock(
         actions: vec![Action::Ignore("WHOAREYOU packet already sent.".to_string())],
     });
     behaviours.push_back(Behaviour {
-        expect: Expect::Handshake(Request::FINDNODE),
+        expect: Expect::Handshake(Request::FindNode),
         actions: vec![Action::EstablishSession, Action::Ignore("todo".to_string())],
     });
     // TODO: handle PING request

--- a/src/concurrent_requests/whoareyou_timeout.rs
+++ b/src/concurrent_requests/whoareyou_timeout.rs
@@ -1,0 +1,165 @@
+use crate::concurrent_requests::InstanceInfo;
+use crate::mock::Mock;
+use crate::utils::publish_and_collect;
+use discv5::enr::{CombinedKey, EnrBuilder};
+use discv5::{Discv5, Discv5Config, Discv5ConfigBuilder, Enr, ListenConfig};
+use std::net::Ipv4Addr;
+use std::time::Duration;
+use testground::client::Client;
+use tracing::error;
+
+const STATE_DISCV5_STARTED: &str = "state_discv5_started";
+const STATE_SENT_RANDOM_PACKET: &str = "state_sent_random_packet";
+const STATE_FINISHED: &str = "state_finished";
+
+pub(crate) async fn run(client: Client) -> Result<(), Box<dyn std::error::Error>> {
+    let run_parameters = client.run_parameters();
+    let ip = run_parameters
+        .data_network_ip()?
+        .expect("IP address for the data network");
+
+    // ////////////////////////
+    // Construct local Enr
+    // ////////////////////////
+    let enr_key = CombinedKey::generate_secp256k1();
+    let enr = EnrBuilder::new("v4")
+        .ip(ip)
+        .udp4(9000)
+        .build(&enr_key)
+        .expect("enr");
+
+    // //////////////////////////////////////////////////////////////
+    // Collect information of all participants in the test case
+    // //////////////////////////////////////////////////////////////
+    let instance_info = InstanceInfo {
+        seq: client.global_seq(),
+        enr: enr.clone(),
+    };
+    client.record_message(format!(
+        "seq: {}, node_id: {}, ip: {}",
+        instance_info.seq,
+        instance_info.enr.node_id(),
+        ip
+    ));
+
+    let another_instance_info = {
+        let participants = publish_and_collect(&client, instance_info).await?;
+        assert_eq!(2, participants.len());
+
+        let info = participants
+            .into_iter()
+            .filter(|p| p.seq != client.global_seq())
+            .collect::<Vec<_>>();
+        assert!(!info.is_empty());
+
+        info.first().unwrap().clone()
+    };
+
+    // ////////////////////////
+    // Discv5 config
+    // ////////////////////////
+    let listen_config = ListenConfig::Ipv4 {
+        ip: Ipv4Addr::UNSPECIFIED,
+        port: 9000,
+    };
+    let config = Discv5ConfigBuilder::new(listen_config)
+        .request_timeout(Duration::from_secs(5))
+        .build();
+
+    match client.global_seq() {
+        1 => run_discv5(client, enr, enr_key, config, another_instance_info).await?,
+        2 => run_mock(client, enr, config, another_instance_info).await?,
+        _ => unreachable!(),
+    }
+
+    Ok(())
+}
+
+async fn run_discv5(
+    client: Client,
+    enr: Enr,
+    enr_key: CombinedKey,
+    config: Discv5Config,
+    another_instance_info: InstanceInfo,
+) -> Result<(), Box<dyn std::error::Error>> {
+    // ////////////////////////
+    // Start discv5
+    // ////////////////////////
+    let mut discv5: Discv5 = Discv5::new(enr.clone(), enr_key, config)?;
+    discv5.start().await.expect("Start Discovery v5 server");
+
+    client
+        .signal_and_wait(
+            STATE_DISCV5_STARTED,
+            client.run_parameters().test_instance_count,
+        )
+        .await?;
+
+    // Wait until the mock send a random packet.
+    client
+        .signal_and_wait(
+            STATE_SENT_RANDOM_PACKET,
+            client.run_parameters().test_instance_count,
+        )
+        .await?;
+
+    // Sent requests in parallel.
+    let mut handles = vec![];
+    for _ in 0..2 {
+        let fut = discv5.find_node_designated_peer(another_instance_info.enr.clone(), vec![0]);
+        handles.push(tokio::spawn(fut));
+    }
+
+    for h in handles {
+        if let Err(e) = h.await.unwrap() {
+            error!("FINDNODE request failed: {e}");
+        }
+    }
+
+    client
+        .signal_and_wait(STATE_FINISHED, client.run_parameters().test_instance_count)
+        .await?;
+
+    client.record_success().await?;
+    Ok(())
+}
+
+async fn run_mock(
+    client: Client,
+    enr: Enr,
+    config: Discv5Config,
+    another_instance_info: InstanceInfo,
+) -> Result<(), Box<dyn std::error::Error>> {
+    // ////////////////////////
+    // Start mock
+    // ////////////////////////
+    let mut mock = Mock::start(enr, config).await;
+
+    client
+        .signal_and_wait(
+            STATE_DISCV5_STARTED,
+            client.run_parameters().test_instance_count,
+        )
+        .await?;
+
+    // Send a random packet.
+    // The receiver of the packet reply with WHOAREYOU packet but this mock drops it without replying.
+    if let Err(e) = mock.send_random_packet(another_instance_info.enr) {
+        error!("Failed to send random packet: {e}");
+    }
+    tokio::time::sleep(Duration::from_secs(1)).await;
+
+    client
+        .signal_and_wait(
+            STATE_SENT_RANDOM_PACKET,
+            client.run_parameters().test_instance_count,
+        )
+        .await?;
+
+    client
+        .signal_and_wait(STATE_FINISHED, client.run_parameters().test_instance_count)
+        .await?;
+
+    client.record_success().await?;
+    Ok(())
+}

--- a/src/concurrent_requests/whoareyou_timeout.rs
+++ b/src/concurrent_requests/whoareyou_timeout.rs
@@ -1,5 +1,5 @@
 use crate::concurrent_requests::InstanceInfo;
-use crate::mock::{Action, Behaviour, Expect, Mock, Request};
+use crate::mock::{Action, Behaviour, Behaviours, Expect, Mock, Request};
 use crate::utils::publish_and_collect;
 use discv5::enr::{CombinedKey, EnrBuilder};
 use discv5::{Discv5, Enr, ListenConfig};
@@ -155,7 +155,7 @@ async fn run_mock(
         actions: vec![Action::EstablishSession, Action::Ignore("todo".to_string())],
     });
     // TODO: handle PING request
-    let mut mock = Mock::start(enr, enr_key, config, behaviours).await;
+    let mut mock = Mock::start(enr, enr_key, config, Behaviours::Sequential(behaviours)).await;
 
     client
         .signal_and_wait(

--- a/src/concurrent_requests/whoareyou_timeout.rs
+++ b/src/concurrent_requests/whoareyou_timeout.rs
@@ -1,7 +1,7 @@
 use crate::concurrent_requests::InstanceInfo;
 use crate::mock::{Action, Behaviour, Behaviours, Expect, Mock, Request};
 use crate::utils::publish_and_collect;
-use discv5::enr::{CombinedKey, EnrBuilder};
+use discv5::enr::CombinedKey;
 use discv5::{Discv5, Enr, ListenConfig};
 use std::collections::VecDeque;
 use std::net::Ipv4Addr;
@@ -23,7 +23,7 @@ pub(crate) async fn run(client: Client) -> Result<(), Box<dyn std::error::Error>
     // Construct local Enr
     // ////////////////////////
     let enr_key = CombinedKey::generate_secp256k1();
-    let enr = EnrBuilder::new("v4")
+    let enr = Enr::builder()
         .ip(ip)
         .udp4(9000)
         .build(&enr_key)

--- a/src/concurrent_requests/whoareyou_timeout.rs
+++ b/src/concurrent_requests/whoareyou_timeout.rs
@@ -138,21 +138,21 @@ async fn run_mock(
     let mut behaviours = VecDeque::new();
     behaviours.push_back(Behaviour {
         expect: Expect::WhoAreYou,
-        action: Action::Ignore(
+        actions: vec![Action::Ignore(
             "Ingore WHOAREYOU packet to make happen a challenge timeout on Node1 side.".to_string(),
-        ),
+        )],
     });
     behaviours.push_back(Behaviour {
         expect: Expect::MessageWithoutSession,
-        action: Action::SendWhoAreYou,
+        actions: vec![Action::SendWhoAreYou],
     });
     behaviours.push_back(Behaviour {
         expect: Expect::MessageWithoutSession,
-        action: Action::Ignore("WHOAREYOU packet already sent.".to_string()),
+        actions: vec![Action::Ignore("WHOAREYOU packet already sent.".to_string())],
     });
     behaviours.push_back(Behaviour {
         expect: Expect::Handshake(Request::FINDNODE),
-        action: Action::EstablishSession(Box::new(Action::Ignore("todo".to_string()))),
+        actions: vec![Action::EstablishSession, Action::Ignore("todo".to_string())],
     });
     // TODO: handle PING request
     let mut mock = Mock::start(enr, enr_key, config, behaviours).await;

--- a/src/eclipse/mod.rs
+++ b/src/eclipse/mod.rs
@@ -1,8 +1,8 @@
 use crate::utils::publish_and_collect;
 use discv5::enr::k256::elliptic_curve::rand_core::RngCore;
 use discv5::enr::k256::elliptic_curve::rand_core::SeedableRng;
-use discv5::enr::{CombinedKey, EnrBuilder, NodeId};
-use discv5::{enr, Discv5, Enr, ListenConfig};
+use discv5::enr::{CombinedKey, NodeId};
+use discv5::{Discv5, Enr, ListenConfig};
 use serde::{Deserialize, Serialize};
 use std::u64;
 use testground::client::Client;
@@ -59,7 +59,7 @@ impl MonopolizingByIncomingNodes {
         // Construct a local Enr
         // ////////////////////////
         let enr_key = Self::generate_deterministic_keypair(client.group_seq(), &role);
-        let enr = EnrBuilder::new("v4")
+        let enr = Enr::builder()
             .ip(run_parameters
                 .data_network_ip()?
                 .expect("IP address for the data network"))

--- a/src/eclipse/mod.rs
+++ b/src/eclipse/mod.rs
@@ -2,7 +2,7 @@ use crate::utils::publish_and_collect;
 use discv5::enr::k256::elliptic_curve::rand_core::RngCore;
 use discv5::enr::k256::elliptic_curve::rand_core::SeedableRng;
 use discv5::enr::{CombinedKey, EnrBuilder, NodeId};
-use discv5::{enr, Discv5, Discv5ConfigBuilder, Enr, ListenConfig};
+use discv5::{enr, Discv5, Enr, ListenConfig};
 use serde::{Deserialize, Serialize};
 use std::u64;
 use testground::client::Client;
@@ -70,7 +70,7 @@ impl MonopolizingByIncomingNodes {
         // //////////////////////////////////////////////////////////////
         // Start Discovery v5 server
         // //////////////////////////////////////////////////////////////
-        let discv5_config = Discv5ConfigBuilder::new(ListenConfig::default())
+        let discv5_config = discv5::ConfigBuilder::new(ListenConfig::default())
             .incoming_bucket_limit(
                 run_parameters
                     .test_instance_params

--- a/src/eclipse/mod.rs
+++ b/src/eclipse/mod.rs
@@ -177,7 +177,7 @@ impl MonopolizingByIncomingNodes {
         discv5: Discv5,
         client: Client,
         honest: &InstanceInfo,
-        attackers: &Vec<InstanceInfo>,
+        attackers: &[InstanceInfo],
     ) -> Result<(), Box<dyn std::error::Error>> {
         // Wait until the attacker has done its attack.
         client

--- a/src/enr_update/mod.rs
+++ b/src/enr_update/mod.rs
@@ -4,7 +4,7 @@ use crate::enr_update::params::Params;
 use crate::utils::publish_and_collect;
 use chrono::Local;
 use discv5::enr::{CombinedKey, EnrBuilder};
-use discv5::{Discv5, Discv5ConfigBuilder, Discv5Event, Enr, ListenConfig};
+use discv5::{Discv5, Enr, ListenConfig};
 use serde::{Deserialize, Serialize};
 use std::time::Duration;
 use testground::client::Client;
@@ -53,7 +53,7 @@ pub(super) async fn run(client: Client) -> Result<(), Box<dyn std::error::Error>
     let mut discv5: Discv5 = Discv5::new(
         enr,
         enr_key,
-        Discv5ConfigBuilder::new(ListenConfig::default())
+        discv5::ConfigBuilder::new(ListenConfig::default())
             .ping_interval(Duration::from_secs(params.ping_interval))
             .build(),
     )?;
@@ -77,7 +77,7 @@ pub(super) async fn run(client: Client) -> Result<(), Box<dyn std::error::Error>
 
         task::spawn(async move {
             while let Some(event) = event_stream.recv().await {
-                if let Discv5Event::SocketUpdated(socket_addr) = event {
+                if let discv5::Event::SocketUpdated(socket_addr) = event {
                     sender.send(socket_addr).unwrap();
                     break;
                 }

--- a/src/enr_update/mod.rs
+++ b/src/enr_update/mod.rs
@@ -3,7 +3,7 @@ mod params;
 use crate::enr_update::params::Params;
 use crate::utils::publish_and_collect;
 use chrono::Local;
-use discv5::enr::{CombinedKey, EnrBuilder};
+use discv5::enr::CombinedKey;
 use discv5::{Discv5, Enr, ListenConfig};
 use serde::{Deserialize, Serialize};
 use std::time::Duration;
@@ -31,11 +31,9 @@ pub(super) async fn run(client: Client) -> Result<(), Box<dyn std::error::Error>
     let enr_key = CombinedKey::generate_secp256k1();
 
     let enr = if client.global_seq() == 1 {
-        EnrBuilder::new("v4")
-            .build(&enr_key)
-            .expect("Construct an Enr")
+        Enr::builder().build(&enr_key).expect("Construct an Enr")
     } else {
-        EnrBuilder::new("v4")
+        Enr::builder()
             .ip(run_parameters
                 .data_network_ip()?
                 .expect("IP address for the data network"))

--- a/src/find_node/mod.rs
+++ b/src/find_node/mod.rs
@@ -1,7 +1,7 @@
 use crate::utils::publish_and_collect;
 use chrono::Local;
 use discv5::enr::{CombinedKey, EnrBuilder, NodeId};
-use discv5::{Discv5, Discv5ConfigBuilder, Enr, Key, ListenConfig};
+use discv5::{Discv5, Enr, Key, ListenConfig};
 use serde::{Deserialize, Serialize};
 use testground::client::Client;
 use testground::WriteQuery;
@@ -59,7 +59,7 @@ pub(super) async fn run(client: Client) -> Result<(), Box<dyn std::error::Error>
     let mut discv5: Discv5 = Discv5::new(
         enr,
         enr_key,
-        Discv5ConfigBuilder::new(ListenConfig::default()).build(),
+        discv5::ConfigBuilder::new(ListenConfig::default()).build(),
     )?;
     discv5.start().await.expect("Start Discovery v5 server");
 

--- a/src/find_node/mod.rs
+++ b/src/find_node/mod.rs
@@ -1,6 +1,6 @@
 use crate::utils::publish_and_collect;
 use chrono::Local;
-use discv5::enr::{CombinedKey, EnrBuilder, NodeId};
+use discv5::enr::{CombinedKey, NodeId};
 use discv5::{Discv5, Enr, Key, ListenConfig};
 use serde::{Deserialize, Serialize};
 use testground::client::Client;
@@ -42,7 +42,7 @@ pub(super) async fn run(client: Client) -> Result<(), Box<dyn std::error::Error>
     // Construct a local Enr
     // ////////////////////////
     let enr_key = CombinedKey::generate_secp256k1();
-    let enr = EnrBuilder::new("v4")
+    let enr = Enr::builder()
         .ip(run_parameters
             .data_network_ip()?
             .expect("IP address for the data network"))

--- a/src/ip_change/mod.rs
+++ b/src/ip_change/mod.rs
@@ -2,7 +2,7 @@ mod params;
 
 use crate::ip_change::params::Params;
 use crate::utils::publish_and_collect;
-use discv5::enr::{CombinedKey, EnrBuilder};
+use discv5::enr::CombinedKey;
 use discv5::{Discv5, Enr, ListenConfig};
 use serde::{Deserialize, Serialize};
 use std::net::{IpAddr, Ipv4Addr};
@@ -32,7 +32,7 @@ pub(crate) async fn run(client: Client) -> Result<(), Box<dyn std::error::Error>
     // Construct local Enr
     // ////////////////////////
     let enr_key = CombinedKey::generate_secp256k1();
-    let enr = EnrBuilder::new("v4")
+    let enr = Enr::builder()
         .ip(ip)
         .udp4(9000)
         .build(&enr_key)

--- a/src/ip_change/mod.rs
+++ b/src/ip_change/mod.rs
@@ -120,7 +120,7 @@ pub(crate) async fn run(client: Client) -> Result<(), Box<dyn std::error::Error>
     tokio::time::sleep(Duration::from_secs(params.duration_after)).await;
 
     if instance_info.seq == 1 {
-        println!("debugggg: {:?}", discv5.table_entries());
+        println!("debug: {:?}", discv5.table_entries());
     }
 
     client.record_success().await?;

--- a/src/ip_change/mod.rs
+++ b/src/ip_change/mod.rs
@@ -3,7 +3,7 @@ mod params;
 use crate::ip_change::params::Params;
 use crate::utils::publish_and_collect;
 use discv5::enr::{CombinedKey, EnrBuilder};
-use discv5::{Discv5, Discv5ConfigBuilder, Enr, ListenConfig};
+use discv5::{Discv5, Enr, ListenConfig};
 use serde::{Deserialize, Serialize};
 use std::net::{IpAddr, Ipv4Addr};
 use std::time::Duration;
@@ -45,7 +45,7 @@ pub(crate) async fn run(client: Client) -> Result<(), Box<dyn std::error::Error>
         ip: Ipv4Addr::UNSPECIFIED,
         port: 9000,
     };
-    let config = Discv5ConfigBuilder::new(listen_config)
+    let config = discv5::ConfigBuilder::new(listen_config)
         .vote_duration(Duration::from_secs(params.vote_duration))
         .ping_interval(Duration::from_secs(params.ping_interval))
         .enr_peer_update_min(run_parameters.test_instance_count as usize - 1)

--- a/src/main.rs
+++ b/src/main.rs
@@ -67,6 +67,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         "concurrent-requests_whoareyou-timeout" => {
             concurrent_requests::whoareyou_timeout::run(client).await?
         }
+        "concurrent-requests_before-establishing-session" => {
+            concurrent_requests::before_establishing_session::run(client).await?
+        }
         "eclipse-attack-monopolizing-by-incoming-nodes" => {
             eclipse::MonopolizingByIncomingNodes::new()
                 .run(client.clone())

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ mod find_node;
 mod ip_change;
 mod mock;
 mod sandbox;
+mod talk;
 mod utils;
 
 use testground::client::Client;
@@ -79,6 +80,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         "enr-update" => enr_update::run(client.clone()).await?,
         "ip-change" => ip_change::run(client).await?,
         "sandbox" => sandbox::run(client).await?,
+        "talk" => talk::run(client).await?,
         _ => unreachable!(),
     };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ mod eclipse;
 mod enr_update;
 mod find_node;
 mod ip_change;
+mod mock;
 mod utils;
 
 use testground::client::Client;
@@ -63,6 +64,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     match client.run_parameters().test_case.clone().as_str() {
         "find-node" => find_node::run(client.clone()).await?,
         "concurrent-requests" => concurrent_requests::run(client).await?,
+        "concurrent-requests_whoareyou-timeout" => {
+            concurrent_requests::whoareyou_timeout::run(client).await?
+        }
         "eclipse-attack-monopolizing-by-incoming-nodes" => {
             eclipse::MonopolizingByIncomingNodes::new()
                 .run(client.clone())

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+mod concurrent_requests;
 mod eclipse;
 mod enr_update;
 mod find_node;
@@ -61,6 +62,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // //////////////////////////////////////////////////////////////
     match client.run_parameters().test_case.clone().as_str() {
         "find-node" => find_node::run(client.clone()).await?,
+        "concurrent-requests" => concurrent_requests::run(client).await?,
         "eclipse-attack-monopolizing-by-incoming-nodes" => {
             eclipse::MonopolizingByIncomingNodes::new()
                 .run(client.clone())

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ mod enr_update;
 mod find_node;
 mod ip_change;
 mod mock;
+mod sandbox;
 mod utils;
 
 use testground::client::Client;
@@ -77,6 +78,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
         "enr-update" => enr_update::run(client.clone()).await?,
         "ip-change" => ip_change::run(client).await?,
+        "sandbox" => sandbox::run(client).await?,
         _ => unreachable!(),
     };
 

--- a/src/mock/crypto.rs
+++ b/src/mock/crypto.rs
@@ -11,7 +11,6 @@ const NODE_ID_LENGTH: usize = 32;
 const INFO_LENGTH: usize = 26 + 2 * NODE_ID_LENGTH;
 const KEY_LENGTH: usize = 16;
 const KEY_AGREEMENT_STRING: &str = "discovery v5 key agreement";
-const ID_SIGNATURE_TEXT: &str = "discovery v5 identity proof";
 
 type Key = [u8; KEY_LENGTH];
 

--- a/src/mock/crypto.rs
+++ b/src/mock/crypto.rs
@@ -1,0 +1,63 @@
+use discv5::enr::{CombinedKey, k256, NodeId};
+use discv5::enr::k256::sha2::Sha256;
+use discv5::packet::ChallengeData;
+use hkdf::Hkdf;
+
+const NODE_ID_LENGTH: usize = 32;
+const INFO_LENGTH: usize = 26 + 2 * NODE_ID_LENGTH;
+const KEY_LENGTH: usize = 16;
+const KEY_AGREEMENT_STRING: &str = "discovery v5 key agreement";
+const ID_SIGNATURE_TEXT: &str = "discovery v5 identity proof";
+
+type Key = [u8; KEY_LENGTH];
+
+/// Derives the session keys for a public key type that matches the local keypair.
+pub(crate) fn derive_keys_from_pubkey(
+    local_key: &CombinedKey,
+    local_id: &NodeId,
+    remote_id: &NodeId,
+    challenge_data: &ChallengeData,
+    ephem_pubkey: &[u8],
+) -> Result<(Key, Key), String> {
+    todo!()
+    // let secret = {
+    //     match local_key {
+    //         CombinedKey::Secp256k1(key) => {
+    //             // convert remote pubkey into secp256k1 public key
+    //             // the key type should match our own node record
+    //             todo!();
+    //             // let remote_pubkey = k256::ecdsa::VerifyingKey::from_sec1_bytes(ephem_pubkey)
+    //             //     .map_err(|_| "Error::InvalidRemotePublicKey".to_string())?;
+    //             // ecdh(&remote_pubkey, key)
+    //         }
+    //         CombinedKey::Ed25519(_) => return Err("Error::KeyTypeNotSupported(Ed25519)".to_string()),
+    //     }
+    // };
+    //
+    // derive_key(&secret, remote_id, local_id, challenge_data)
+}
+
+fn derive_key(
+    secret: &[u8],
+    first_id: &NodeId,
+    second_id: &NodeId,
+    challenge_data: &ChallengeData,
+) -> Result<(Key, Key), String> {
+    let mut info = [0u8; INFO_LENGTH];
+    info[0..26].copy_from_slice(KEY_AGREEMENT_STRING.as_bytes());
+    info[26..26 + NODE_ID_LENGTH].copy_from_slice(&first_id.raw());
+    info[26 + NODE_ID_LENGTH..].copy_from_slice(&second_id.raw());
+
+    let hk = Hkdf::<Sha256>::new(Some(challenge_data.as_ref()), secret);
+
+    let mut okm = [0u8; 2 * KEY_LENGTH];
+    hk.expand(&info, &mut okm)
+        .map_err(|_| "Error::KeyDerivationFailed".to_string())?;
+
+    let mut initiator_key: Key = Default::default();
+    let mut recipient_key: Key = Default::default();
+    initiator_key.copy_from_slice(&okm[0..KEY_LENGTH]);
+    recipient_key.copy_from_slice(&okm[KEY_LENGTH..2 * KEY_LENGTH]);
+
+    Ok((initiator_key, recipient_key))
+}

--- a/src/mock/crypto.rs
+++ b/src/mock/crypto.rs
@@ -1,5 +1,5 @@
-use discv5::enr::{CombinedKey, k256, NodeId};
 use discv5::enr::k256::sha2::Sha256;
+use discv5::enr::{k256, CombinedKey, NodeId};
 use discv5::packet::ChallengeData;
 use hkdf::Hkdf;
 

--- a/src/mock/ecdh.rs
+++ b/src/mock/ecdh.rs
@@ -1,0 +1,20 @@
+use discv5::enr::k256;
+use enr::k256::ecdsa::{SigningKey, VerifyingKey};
+use enr::k256::elliptic_curve::sec1::ToEncodedPoint;
+
+pub fn ecdh(public_key: &VerifyingKey, secret_key: &SigningKey) -> Vec<u8> {
+    k256::PublicKey::from_affine(
+        (k256::PublicKey::from_sec1_bytes(public_key.to_sec1_bytes().as_ref())
+            .unwrap()
+            .to_projective()
+            * k256::SecretKey::from_slice(&secret_key.to_bytes())
+                .unwrap()
+                .to_nonzero_scalar()
+                .as_ref())
+        .to_affine(),
+    )
+    .unwrap()
+    .to_encoded_point(true)
+    .as_bytes()
+    .to_vec()
+}

--- a/src/mock/handler.rs
+++ b/src/mock/handler.rs
@@ -2,7 +2,7 @@ use crate::mock;
 use crate::mock::session::Session;
 use crate::mock::socket::Socket;
 use crate::mock::{
-    Action, Behaviour, Behaviours, CustomResponse, CustomResponseId, Expect, Request,
+    Action, Behaviours, CustomResponse, CustomResponseId, Expect, Request,
 };
 use discv5::enr::{CombinedKey, NodeId};
 use discv5::handler::{NodeAddress, NodeContact};
@@ -10,8 +10,9 @@ use discv5::packet::{ChallengeData, IdNonce, Packet, PacketKind};
 use discv5::rpc::{Message, RequestBody};
 use discv5::socket::{InboundPacket, OutboundPacket};
 use discv5::{DefaultProtocolId, Enr};
-use std::collections::{HashMap, VecDeque};
+use std::collections::HashMap;
 use std::net::IpAddr;
+use std::num::NonZeroU16;
 use tokio::sync::mpsc;
 use tokio::sync::mpsc::{Receiver, UnboundedSender};
 use tracing::{info, warn};
@@ -402,7 +403,7 @@ impl Handler {
                         body: discv5::rpc::ResponseBody::Pong {
                             enr_seq: self.enr.seq(),
                             ip: IpAddr::from(self.enr.ip4().unwrap()),
-                            port: self.enr.udp4().unwrap(),
+                            port: NonZeroU16::new(self.enr.udp4().unwrap()).unwrap(),
                         },
                     },
                 )

--- a/src/mock/handler.rs
+++ b/src/mock/handler.rs
@@ -156,7 +156,7 @@ impl Handler {
             PacketKind::Handshake { .. } => {
                 self.do_actions(inbound_packet, behaviour.handshake.clone())
                     .await;
-            }
+            } // PacketKind::SessionMessage { .. } => todo!(),
         }
     }
 
@@ -259,6 +259,8 @@ impl Handler {
                                     }
                                 }
                                 Message::Response(_) => todo!(),
+                                // Message::RelayInitNotification(_) => todo!(),
+                                // Message::RelayMsgNotification(_) => todo!(),
                             }
                         } else {
                             panic!("Session does not exist.")
@@ -272,7 +274,7 @@ impl Handler {
 
                 // Action
                 self.do_actions(inbound_packet, behaviour.actions).await;
-            }
+            } // PacketKind::SessionMessage { .. } => todo!(),
         }
     }
 
@@ -309,6 +311,8 @@ impl Handler {
                         let request = match decode_message(session, &inbound_packet) {
                             Message::Request(request) => request,
                             Message::Response(_) => unreachable!(),
+                            // Message::RelayInitNotification(_) => todo!(),
+                            // Message::RelayMsgNotification(_) => todo!(),
                         };
                         match response {
                             mock::Response::Default => {
@@ -337,6 +341,8 @@ impl Handler {
                     self.captured_requests.push(request);
                 }
                 Message::Response(_) => unreachable!(),
+                // Message::RelayInitNotification(_) => todo!(),
+                // Message::RelayMsgNotification(_) => todo!(),
             }
         } else {
             panic!("Session does not exist.")
@@ -480,6 +486,7 @@ fn node_address(inbound_packet: &InboundPacket) -> NodeAddress {
         PacketKind::Message { src_id } => src_id,
         PacketKind::WhoAreYou { .. } => unreachable!(),
         PacketKind::Handshake { src_id, .. } => src_id,
+        // PacketKind::SessionMessage { .. } => todo!(),
     };
 
     NodeAddress {

--- a/src/mock/handler.rs
+++ b/src/mock/handler.rs
@@ -1,12 +1,24 @@
 use crate::mock::socket::Socket;
-use discv5::enr::NodeId;
-use discv5::handler::NodeContact;
-use discv5::packet::{Packet, PacketKind};
+use crate::mock::{Action, Behaviour, Expect};
+use discv5::enr::{CombinedKey, NodeId};
+use discv5::handler::{NodeAddress, NodeContact};
+use discv5::packet::{ChallengeData, IdNonce, MessageNonce, Packet, PacketKind};
 use discv5::socket::{InboundPacket, OutboundPacket};
-use discv5::{Discv5Config, Enr};
+use discv5::{DefaultProtocolId, Enr};
+use std::collections::{HashMap, VecDeque};
 use tokio::sync::mpsc;
 use tokio::sync::mpsc::{Receiver, UnboundedSender};
 use tracing::{info, warn};
+use crate::mock::session::Session;
+
+#[derive(Debug)]
+/// A Challenge (WHOAREYOU) object used to handle and send WHOAREYOU requests.
+pub struct Challenge {
+    /// The challenge data received from the node.
+    pub data: ChallengeData,
+    /// The remote's ENR if we know it. We can receive a challenge from an unknown node.
+    pub remote_enr: Option<Enr>,
+}
 
 pub(crate) enum HandlerIn {
     SendRandomPacket(NodeContact),
@@ -15,15 +27,20 @@ pub(crate) enum HandlerIn {
 pub(crate) enum HandlerOut {}
 
 pub(crate) struct Handler {
+    local_key: CombinedKey,
     node_id: NodeId,
     from_mock: mpsc::UnboundedReceiver<HandlerIn>,
     socket: Socket,
+    behaviours: VecDeque<Behaviour>,
+    active_challenges: HashMap<NodeAddress, Challenge>,
 }
 
 impl Handler {
     pub(crate) async fn spawn(
         enr: Enr,
-        config: Discv5Config,
+        enr_key: CombinedKey,
+        config: discv5::Config,
+        behaviours: VecDeque<Behaviour>,
     ) -> (UnboundedSender<HandlerIn>, Receiver<HandlerOut>) {
         let (handler_send, from_mock) = mpsc::unbounded_channel();
         let (_to_mock, handler_recv) = mpsc::channel(50);
@@ -43,9 +60,12 @@ impl Handler {
             .expect("Executor must be present")
             .spawn(Box::pin(async move {
                 let mut handler = Handler {
+                    local_key: enr_key,
                     node_id,
                     from_mock,
                     socket,
+                    behaviours,
+                    active_challenges: HashMap::new(),
                 };
 
                 handler.start().await;
@@ -61,7 +81,7 @@ impl Handler {
                     self.process_handler_request(handler_request).await;
                 }
                 Some(inbound_packet) = self.socket.recv.recv() => {
-                    self.process_inbound_packet(inbound_packet);
+                    self.process_inbound_packet(inbound_packet).await;
                 }
             }
         }
@@ -83,13 +103,150 @@ impl Handler {
         }
     }
 
-    pub(crate) fn process_inbound_packet(&self, inbound_packet: InboundPacket) {
+    pub(crate) async fn process_inbound_packet(&mut self, inbound_packet: InboundPacket) {
+        let inbound_packet_kind = inbound_packet.header.kind.clone();
+        macro_rules! next_behaviour {
+            () => {{
+                self.behaviours.pop_front().expect(
+                    format!(
+                        "No behaviour. inbound_packet:{:?}",
+                        inbound_packet_kind
+                    )
+                    .as_str(),
+                )
+            }};
+        }
+
         match inbound_packet.header.kind {
-            PacketKind::Message { .. } => todo!(),
-            PacketKind::WhoAreYou { .. } => {
-                info!("Received WHOAREYOU packet but dropped it without replying.")
+            PacketKind::WhoAreYou { id_nonce, .. } => {
+                let behaviour = next_behaviour!();
+                match behaviour.expect {
+                    Expect::WhoAreYou => {
+                        info!("Received WHOAREYOU packet. id_nonce:{:?}", id_nonce)
+                    }
+                    _ => panic!(
+                        "Unexpected inbound packet. expected:{:?}, actual:{:?}",
+                        behaviour.expect, inbound_packet.header.kind
+                    ),
+                }
+
+                match behaviour.action {
+                    Action::Ignore(reason) => info!(
+                        "Ignoring WHOAREYOU packet. id_nonce:{:?}, reason:{}",
+                        id_nonce, reason
+                    ),
+                    Action::SendWhoAreYou => unreachable!(),
+                    Action::EstablishSession(_) => unreachable!(),
+                }
             }
-            PacketKind::Handshake { .. } => todo!(),
+            PacketKind::Handshake {
+                src_id,
+                id_nonce_sig,
+                ephem_pubkey,
+                enr_record,
+            } => {
+                let behaviour = next_behaviour!();
+                let expected_request_kind = match behaviour.expect {
+                    Expect::Handshake(expected_request_kind) => {
+                        info!("Received Handshake.");
+                        expected_request_kind
+                    }
+                    _ => panic!(
+                        "Unexpected inbound packet. expected:{:?}, actual:{:?}",
+                        behaviour.expect, inbound_packet_kind
+                    ),
+                };
+
+                match behaviour.action {
+                    Action::Ignore(_) => todo!(),
+                    Action::SendWhoAreYou => unreachable!(),
+                    Action::EstablishSession(next_action) => {
+                        info!("TODO: establish session");
+                        let node_address = NodeAddress {
+                            socket_addr: inbound_packet.src_address,
+                            node_id: src_id,
+                        };
+                        if let Some(challenge) = self.active_challenges.remove(&node_address) {
+                            self.establish_session(node_address, challenge, &ephem_pubkey, enr_record);
+                        } else {
+                            panic!("No active challenge");
+                        }
+                    }
+                }
+            }
+            PacketKind::Message { src_id } => {
+                let behaviour = next_behaviour!();
+                match behaviour.expect {
+                    Expect::MessageWithoutSession => {
+                        info!("Received Message without session.");
+                        // TODO: check session existence
+                    }
+                    _ => panic!(
+                        "Unexpected inbound packet. expected:{:?}, actual:{:?}",
+                        behaviour.expect, inbound_packet_kind
+                    ),
+                }
+
+                match behaviour.action {
+                    Action::Ignore(reason) => info!("Ignoring Message packet. reason:{}", reason),
+                    Action::SendWhoAreYou => {
+                        let node_address = NodeAddress {
+                            socket_addr: inbound_packet.src_address,
+                            node_id: src_id,
+                        };
+                        self.send_challenge(node_address, inbound_packet.header.message_nonce)
+                            .await;
+                    }
+                    Action::EstablishSession(_) => unreachable!(),
+                }
+                // let node_address = NodeAddress {
+                //     socket_addr: inbound_packet.src_address,
+                //     node_id: src_id,
+                // };
+                // self.handle_message(
+                //     node_address,
+                //     message_nonce,
+                //     &inbound_packet.message,
+                //     &inbound_packet.authenticated_data,
+                // )
+                //     .await
+            }
+        }
+    }
+
+    async fn send_challenge(&mut self, node_address: NodeAddress, message_nonce: MessageNonce) {
+        let id_nonce: IdNonce = rand::random();
+        let packet = Packet::new_whoareyou(message_nonce, id_nonce, 1);
+        let challenge_data =
+            ChallengeData::try_from(packet.authenticated_data::<DefaultProtocolId>().as_slice())
+                .expect("Must be the correct challenge size");
+
+        info!("Sending WHOAREYOU to {}", node_address);
+        self.send(node_address.clone(), packet).await;
+        if let Some(_) = self.active_challenges.insert(node_address, Challenge { data: challenge_data, remote_enr: None }) {
+            panic!("Unexpected call for send_challenge()");
+        }
+    }
+
+    async fn send(&mut self, node_address: NodeAddress, packet: Packet) {
+        let outbound_packet = OutboundPacket {
+            node_address,
+            packet,
+        };
+        self.socket.send.send(outbound_packet).await.unwrap();
+    }
+
+    async fn establish_session(&mut self, node_address: NodeAddress, challenge: Challenge, ephem_pubkey: &[u8], enr_record: Option<Enr>) {
+        match Session::establish_from_challenge(
+            &self.local_key,
+            &self.node_id,
+            &node_address.node_id,
+            challenge,
+            ephem_pubkey,
+            enr_record,
+        ) {
+            Ok(_) => {}
+            Err(_) => {}
         }
     }
 }

--- a/src/mock/handler.rs
+++ b/src/mock/handler.rs
@@ -346,8 +346,7 @@ impl Handler {
     async fn send_challenge(&mut self, inbound_packet: &InboundPacket) {
         let node_address = node_address(inbound_packet);
         let id_nonce: IdNonce = rand::random();
-        let packet =
-            Packet::new_whoareyou(inbound_packet.header.message_nonce, id_nonce, 0);
+        let packet = Packet::new_whoareyou(inbound_packet.header.message_nonce, id_nonce, 0);
         let challenge_data =
             ChallengeData::try_from(packet.authenticated_data::<DefaultProtocolId>().as_slice())
                 .expect("Must be the correct challenge size");

--- a/src/mock/handler.rs
+++ b/src/mock/handler.rs
@@ -1,7 +1,9 @@
 use crate::mock;
 use crate::mock::session::Session;
 use crate::mock::socket::Socket;
-use crate::mock::{Action, Behaviour, Behaviours, CustomResponse, CustomResponseId, Expect, Request};
+use crate::mock::{
+    Action, Behaviour, Behaviours, CustomResponse, CustomResponseId, Expect, Request,
+};
 use discv5::enr::{CombinedKey, NodeId};
 use discv5::handler::{NodeAddress, NodeContact};
 use discv5::packet::{ChallengeData, IdNonce, Packet, PacketKind};
@@ -115,15 +117,19 @@ impl Handler {
     pub(crate) async fn process_inbound_packet(&mut self, inbound_packet: InboundPacket) {
         match self.behaviours {
             Behaviours::Declarative(_) => {
-                self.process_inbound_packet_declarative(inbound_packet).await;
-            },
+                self.process_inbound_packet_declarative(inbound_packet)
+                    .await;
+            }
             Behaviours::Sequential(_) => {
                 self.process_inbound_packet_sequential(inbound_packet).await;
             }
         }
     }
 
-    pub(crate) async fn process_inbound_packet_declarative(&mut self, inbound_packet: InboundPacket) {
+    pub(crate) async fn process_inbound_packet_declarative(
+        &mut self,
+        inbound_packet: InboundPacket,
+    ) {
         let inbound_packet_kind = inbound_packet.header.kind.clone();
         let behaviour = match &self.behaviours {
             Behaviours::Declarative(behaviour) => behaviour,
@@ -137,21 +143,28 @@ impl Handler {
                     node_id: src_id,
                 };
                 if self.sessions.contains_key(&node_address) {
-                    self.do_actions(inbound_packet, behaviour.message.clone()).await;
+                    self.do_actions(inbound_packet, behaviour.message.clone())
+                        .await;
                 } else {
-                    self.do_actions(inbound_packet, behaviour.message_without_session.clone()).await;
+                    self.do_actions(inbound_packet, behaviour.message_without_session.clone())
+                        .await;
                 }
             }
             PacketKind::WhoAreYou { .. } => {
-                self.do_actions(inbound_packet, behaviour.whoareyou.clone()).await;
+                self.do_actions(inbound_packet, behaviour.whoareyou.clone())
+                    .await;
             }
             PacketKind::Handshake { .. } => {
-                self.do_actions(inbound_packet, behaviour.handshake.clone()).await;
+                self.do_actions(inbound_packet, behaviour.handshake.clone())
+                    .await;
             }
         }
     }
 
-    pub(crate) async fn process_inbound_packet_sequential(&mut self, inbound_packet: InboundPacket) {
+    pub(crate) async fn process_inbound_packet_sequential(
+        &mut self,
+        inbound_packet: InboundPacket,
+    ) {
         let inbound_packet_kind = inbound_packet.header.kind.clone();
         let behaviours = match self.behaviours {
             Behaviours::Declarative(_) => unreachable!(),

--- a/src/mock/handler.rs
+++ b/src/mock/handler.rs
@@ -1,9 +1,7 @@
 use crate::mock;
 use crate::mock::session::Session;
 use crate::mock::socket::Socket;
-use crate::mock::{
-    Action, Behaviours, CustomResponse, CustomResponseId, Expect, Request,
-};
+use crate::mock::{Action, Behaviours, CustomResponse, CustomResponseId, Expect, Request};
 use discv5::enr::{CombinedKey, NodeId};
 use discv5::handler::{NodeAddress, NodeContact};
 use discv5::packet::{ChallengeData, IdNonce, Packet, PacketKind};

--- a/src/mock/handler.rs
+++ b/src/mock/handler.rs
@@ -1,0 +1,98 @@
+use crate::mock::socket::Socket;
+use discv5::enr::NodeId;
+use discv5::handler::NodeContact;
+use discv5::packet::{Packet, PacketKind};
+use discv5::socket::{InboundPacket, OutboundPacket};
+use discv5::{Discv5Config, Enr};
+use tokio::sync::mpsc;
+use tokio::sync::mpsc::{Receiver, UnboundedSender};
+use tracing::{info, warn};
+
+pub(crate) enum HandlerIn {
+    SendRandomPacket(NodeContact),
+}
+
+pub(crate) enum HandlerOut {}
+
+pub(crate) struct Handler {
+    node_id: NodeId,
+    service_recv: mpsc::UnboundedReceiver<HandlerIn>,
+    service_send: mpsc::Sender<HandlerOut>,
+    socket: Socket,
+}
+
+impl Handler {
+    pub(crate) async fn spawn(
+        enr: Enr,
+        // key: Arc<RwLock<CombinedKey>>,
+        config: Discv5Config,
+    ) -> (UnboundedSender<HandlerIn>, Receiver<HandlerOut>) {
+        let (handler_send, service_recv) = mpsc::unbounded_channel();
+        let (service_send, handler_recv) = mpsc::channel(50);
+
+        let node_id = enr.node_id();
+
+        let socket = Socket::new(
+            config.executor.clone().expect("Executor must exist"),
+            node_id.clone(),
+            config.listen_config.clone(),
+        )
+        .await;
+
+        config
+            .executor
+            .clone()
+            .expect("Executor must be present")
+            .spawn(Box::pin(async move {
+                let mut handler = Handler {
+                    node_id,
+                    service_recv,
+                    service_send,
+                    socket,
+                };
+
+                handler.start().await;
+            }));
+
+        (handler_send, handler_recv)
+    }
+
+    pub(crate) async fn start(&mut self) {
+        loop {
+            tokio::select! {
+                Some(handler_request) = self.service_recv.recv() => {
+                    self.process_handler_request(handler_request).await;
+                }
+                Some(inbound_packet) = self.socket.recv.recv() => {
+                    self.process_inbound_packet(inbound_packet);
+                }
+            }
+        }
+    }
+
+    pub(crate) async fn process_handler_request(&self, handler_request: HandlerIn) {
+        match handler_request {
+            HandlerIn::SendRandomPacket(node_contact) => {
+                let packet = Packet::new_random(&self.node_id).unwrap();
+                let outbound_packet = OutboundPacket {
+                    node_address: node_contact.node_address(),
+                    packet,
+                };
+
+                if let Err(e) = self.socket.send.send(outbound_packet).await {
+                    warn!("Failed to send OutboundPacket to SendHandler: {e}");
+                }
+            }
+        }
+    }
+
+    pub(crate) fn process_inbound_packet(&self, inbound_packet: InboundPacket) {
+        match inbound_packet.header.kind {
+            PacketKind::Message { .. } => todo!(),
+            PacketKind::WhoAreYou { .. } => {
+                info!("Received WHOAREYOU packet but dropped it without replying.")
+            }
+            PacketKind::Handshake { .. } => todo!(),
+        }
+    }
+}

--- a/src/mock/handler.rs
+++ b/src/mock/handler.rs
@@ -347,7 +347,7 @@ impl Handler {
         let node_address = node_address(inbound_packet);
         let id_nonce: IdNonce = rand::random();
         let packet =
-            Packet::new_whoareyou(inbound_packet.header.message_nonce.clone(), id_nonce, 0);
+            Packet::new_whoareyou(inbound_packet.header.message_nonce, id_nonce, 0);
         let challenge_data =
             ChallengeData::try_from(packet.authenticated_data::<DefaultProtocolId>().as_slice())
                 .expect("Must be the correct challenge size");
@@ -460,7 +460,7 @@ fn decode_message(session: &Session, inbound_packet: &InboundPacket) -> discv5::
     // Decrypt the message
     let message = session
         .decrypt_message(
-            inbound_packet.header.message_nonce.clone(),
+            inbound_packet.header.message_nonce,
             &inbound_packet.message,
             &inbound_packet.authenticated_data,
         )
@@ -471,14 +471,8 @@ fn decode_message(session: &Session, inbound_packet: &InboundPacket) -> discv5::
 
 fn check_request_kind(request: &discv5::rpc::Request, expected: &Request) -> bool {
     match expected {
-        Request::FINDNODE => match request.body {
-            RequestBody::FindNode { .. } => true,
-            _ => false,
-        },
-        Request::Ping => match request.body {
-            RequestBody::Ping { .. } => true,
-            _ => false,
-        },
+        Request::FindNode => matches!(request.body, RequestBody::FindNode { .. }),
+        Request::Ping => matches!(request.body, RequestBody::Ping { .. }),
     }
 }
 

--- a/src/mock/mod.rs
+++ b/src/mock/mod.rs
@@ -5,17 +5,16 @@ mod session;
 mod socket;
 
 use crate::mock::handler::{Handler, HandlerIn};
-use crate::mock::session::Session;
 use discv5::enr::CombinedKey;
-use discv5::handler::{NodeAddress, NodeContact};
+use discv5::handler::NodeContact;
 use discv5::{Enr, IpMode};
-use std::collections::{HashMap, VecDeque};
+use std::collections::VecDeque;
 use tokio::sync::mpsc;
 use tracing::info;
 
 pub struct Behaviour {
     pub expect: Expect,
-    pub action: Action,
+    pub actions: Vec<Action>,
 }
 
 #[derive(Debug)]
@@ -35,7 +34,7 @@ pub enum Request {
 pub enum Action {
     Ignore(String),
     SendWhoAreYou,
-    EstablishSession(Box<Action>),
+    EstablishSession,
     SendResponse(Response),
     CaptureRequest,
 }

--- a/src/mock/mod.rs
+++ b/src/mock/mod.rs
@@ -12,6 +12,18 @@ use std::collections::VecDeque;
 use tokio::sync::mpsc;
 use tracing::info;
 
+pub enum Behaviours {
+    Declarative(DeclarativeBehaviour),
+    Sequential(VecDeque<Behaviour>),
+}
+
+pub struct DeclarativeBehaviour {
+    pub whoareyou: Vec<Action>,
+    pub handshake: Vec<Action>,
+    pub message: Vec<Action>,
+    pub message_without_session: Vec<Action>,
+}
+
 pub struct Behaviour {
     pub expect: Expect,
     pub actions: Vec<Action>,
@@ -31,6 +43,7 @@ pub enum Request {
     Ping,
 }
 
+#[derive(Clone)]
 pub enum Action {
     Ignore(String),
     SendWhoAreYou,
@@ -39,15 +52,18 @@ pub enum Action {
     CaptureRequest,
 }
 
+#[derive(Clone)]
 pub enum Response {
     Default,
     Custom(Vec<CustomResponse>),
 }
 
+#[derive(Clone)]
 pub enum CustomResponseId {
     CapturedRequestId(usize),
 }
 
+#[derive(Clone)]
 pub struct CustomResponse {
     pub id: CustomResponseId,
     pub body: discv5::rpc::ResponseBody,
@@ -63,7 +79,7 @@ impl Mock {
         enr: Enr,
         enr_key: CombinedKey,
         config: discv5::Config,
-        behaviours: VecDeque<Behaviour>,
+        behaviours: Behaviours,
     ) -> Self {
         let (to_handler, _from_handler) = Handler::spawn(enr, enr_key, config, behaviours).await;
 

--- a/src/mock/mod.rs
+++ b/src/mock/mod.rs
@@ -1,13 +1,15 @@
 mod crypto;
+mod ecdh;
 mod handler;
 mod session;
 mod socket;
 
 use crate::mock::handler::{Handler, HandlerIn};
+use crate::mock::session::Session;
 use discv5::enr::CombinedKey;
-use discv5::handler::NodeContact;
+use discv5::handler::{NodeAddress, NodeContact};
 use discv5::{Enr, IpMode};
-use std::collections::VecDeque;
+use std::collections::{HashMap, VecDeque};
 use tokio::sync::mpsc;
 use tracing::info;
 
@@ -21,11 +23,13 @@ pub enum Expect {
     WhoAreYou,
     MessageWithoutSession,
     Handshake(Request),
+    Message(Request),
 }
 
 #[derive(Debug)]
 pub enum Request {
     FINDNODE,
+    Ping,
 }
 
 pub enum Action {

--- a/src/mock/mod.rs
+++ b/src/mock/mod.rs
@@ -1,13 +1,13 @@
-mod handler;
-mod socket;
-mod session;
 mod crypto;
+mod handler;
+mod session;
+mod socket;
 
 use crate::mock::handler::{Handler, HandlerIn};
+use discv5::enr::CombinedKey;
 use discv5::handler::NodeContact;
 use discv5::{Enr, IpMode};
 use std::collections::VecDeque;
-use discv5::enr::CombinedKey;
 use tokio::sync::mpsc;
 use tracing::info;
 

--- a/src/mock/mod.rs
+++ b/src/mock/mod.rs
@@ -12,6 +12,7 @@ use std::collections::VecDeque;
 use tokio::sync::mpsc;
 use tracing::info;
 
+#[allow(dead_code)]
 pub enum Behaviours {
     Declarative(DeclarativeBehaviour),
     Sequential(VecDeque<Behaviour>),
@@ -39,7 +40,7 @@ pub enum Expect {
 
 #[derive(Debug)]
 pub enum Request {
-    FINDNODE,
+    FindNode,
     Ping,
 }
 
@@ -52,6 +53,7 @@ pub enum Action {
     CaptureRequest,
 }
 
+#[allow(dead_code)]
 #[derive(Clone)]
 pub enum Response {
     Default,

--- a/src/mock/mod.rs
+++ b/src/mock/mod.rs
@@ -36,6 +36,22 @@ pub enum Action {
     Ignore(String),
     SendWhoAreYou,
     EstablishSession(Box<Action>),
+    SendResponse(Response),
+    CaptureRequest,
+}
+
+pub enum Response {
+    Default,
+    Custom(Vec<CustomResponse>),
+}
+
+pub enum CustomResponseId {
+    CapturedRequestId(usize),
+}
+
+pub struct CustomResponse {
+    pub id: CustomResponseId,
+    pub body: discv5::rpc::ResponseBody,
 }
 
 pub(crate) struct Mock {

--- a/src/mock/mod.rs
+++ b/src/mock/mod.rs
@@ -1,0 +1,44 @@
+mod handler;
+mod socket;
+
+use crate::mock::handler::{Handler, HandlerIn, HandlerOut};
+use discv5::handler::NodeContact;
+use discv5::{Discv5Config, Enr, IpMode};
+use tokio::sync::mpsc;
+use tracing::info;
+
+pub(crate) struct Mock {
+    config: Discv5Config,
+    enr: Enr,
+    /// The channel to send messages to the handler.
+    handler_send: mpsc::UnboundedSender<HandlerIn>,
+    /// The channel to receive messages from the handler.
+    handler_recv: mpsc::Receiver<HandlerOut>,
+}
+
+impl Mock {
+    pub(crate) async fn start(enr: Enr, config: Discv5Config) -> Self {
+        let (handler_send, handler_recv) = Handler::spawn(enr.clone(), config.clone()).await;
+
+        Mock {
+            config,
+            enr,
+            handler_send,
+            handler_recv,
+        }
+    }
+
+    pub(crate) fn send_random_packet(&mut self, enr: Enr) -> Result<(), String> {
+        let node_contact = NodeContact::try_from_enr(enr, IpMode::Ip4).unwrap();
+        info!(
+            "Sending random packet to {} {}",
+            node_contact.node_id(),
+            node_contact.socket_addr()
+        );
+        self.handler_send
+            .send(HandlerIn::SendRandomPacket(node_contact))
+            .map_err(|e| format!("Failed to send message to the handler: {e}"))?;
+
+        Ok(())
+    }
+}

--- a/src/mock/session.rs
+++ b/src/mock/session.rs
@@ -30,7 +30,7 @@ impl Session {
         local_key: &CombinedKey,
         local_id: &NodeId,
         remote_id: &NodeId,
-        challenge: Challenge,
+        challenge: &Challenge,
         // id_nonce_sig: &[u8],
         ephem_pubkey: &[u8],
         enr_record: Option<Enr>,

--- a/src/mock/session.rs
+++ b/src/mock/session.rs
@@ -1,8 +1,12 @@
 use crate::mock::crypto::derive_keys_from_pubkey;
 use crate::mock::handler::Challenge;
 use discv5::enr::{CombinedKey, NodeId};
-use discv5::Enr;
+use discv5::packet::{MessageNonce, Packet, PacketHeader, PacketKind};
+use discv5::{DefaultProtocolId, Enr};
 use zeroize::Zeroize;
+
+/// The message nonce length (in bytes).
+pub const MESSAGE_NONCE_LENGTH: usize = 12;
 
 #[derive(Zeroize, PartialEq)]
 pub(crate) struct Keys {
@@ -14,11 +18,12 @@ pub(crate) struct Keys {
 
 pub(crate) struct Session {
     keys: Keys,
+    counter: u32,
 }
 
 impl Session {
     pub(crate) fn new(keys: Keys) -> Session {
-        Session { keys }
+        Session { keys, counter: 0 }
     }
 
     pub(crate) fn establish_from_challenge(
@@ -45,5 +50,53 @@ impl Session {
         };
 
         Ok((Session::new(keys), enr_record.unwrap()))
+    }
+
+    pub(crate) fn encrypt_message(
+        &mut self,
+        src_id: NodeId,
+        message: &[u8],
+    ) -> Result<Packet, String> {
+        self.counter += 1;
+
+        // If the message nonce length is ever set below 4 bytes this will explode. The packet
+        // size constants shouldn't be modified.
+        let random_nonce: [u8; MESSAGE_NONCE_LENGTH - 4] = rand::random();
+        let mut message_nonce: MessageNonce = [0u8; MESSAGE_NONCE_LENGTH];
+        message_nonce[..4].copy_from_slice(&self.counter.to_be_bytes());
+        message_nonce[4..].copy_from_slice(&random_nonce);
+
+        // the authenticated data is the IV concatenated with the packet header
+        let iv: u128 = rand::random();
+        let header = PacketHeader {
+            message_nonce,
+            kind: PacketKind::Message { src_id },
+        };
+
+        let mut authenticated_data = iv.to_be_bytes().to_vec();
+        authenticated_data.extend_from_slice(&header.encode::<DefaultProtocolId>());
+
+        let cipher = crate::mock::crypto::encrypt_message(
+            &self.keys.encryption_key,
+            message_nonce,
+            message,
+            &authenticated_data,
+        )?;
+
+        // construct a packet from the header and the cipher text
+        Ok(Packet {
+            iv,
+            header,
+            message: cipher,
+        })
+    }
+
+    pub(crate) fn decrypt_message(
+        &self,
+        message_nonce: MessageNonce,
+        message: &[u8],
+        aad: &[u8],
+    ) -> Result<Vec<u8>, String> {
+        crate::mock::crypto::decrypt_message(&self.keys.decryption_key, message_nonce, message, aad)
     }
 }

--- a/src/mock/session.rs
+++ b/src/mock/session.rs
@@ -1,8 +1,8 @@
-use discv5::Enr;
-use discv5::enr::{CombinedKey, NodeId};
-use zeroize::Zeroize;
 use crate::mock::crypto::derive_keys_from_pubkey;
 use crate::mock::handler::Challenge;
+use discv5::enr::{CombinedKey, NodeId};
+use discv5::Enr;
+use zeroize::Zeroize;
 
 #[derive(Zeroize, PartialEq)]
 pub(crate) struct Keys {

--- a/src/mock/session.rs
+++ b/src/mock/session.rs
@@ -1,0 +1,49 @@
+use discv5::Enr;
+use discv5::enr::{CombinedKey, NodeId};
+use zeroize::Zeroize;
+use crate::mock::crypto::derive_keys_from_pubkey;
+use crate::mock::handler::Challenge;
+
+#[derive(Zeroize, PartialEq)]
+pub(crate) struct Keys {
+    /// The encryption key.
+    encryption_key: [u8; 16],
+    /// The decryption key.
+    decryption_key: [u8; 16],
+}
+
+pub(crate) struct Session {
+    keys: Keys,
+}
+
+impl Session {
+    pub(crate) fn new(keys: Keys) -> Session {
+        Session { keys }
+    }
+
+    pub(crate) fn establish_from_challenge(
+        local_key: &CombinedKey,
+        local_id: &NodeId,
+        remote_id: &NodeId,
+        challenge: Challenge,
+        // id_nonce_sig: &[u8],
+        ephem_pubkey: &[u8],
+        enr_record: Option<Enr>,
+    ) -> Result<(Session, Enr), String> {
+        // generate session keys
+        let (decryption_key, encryption_key) = derive_keys_from_pubkey(
+            local_key,
+            local_id,
+            remote_id,
+            &challenge.data,
+            ephem_pubkey,
+        )?;
+
+        let keys = Keys {
+            encryption_key,
+            decryption_key,
+        };
+
+        Ok((Session::new(keys), enr_record.unwrap()))
+    }
+}

--- a/src/mock/socket.rs
+++ b/src/mock/socket.rs
@@ -1,0 +1,139 @@
+use discv5::enr::NodeId;
+use discv5::packet::Packet;
+use discv5::socket::{InboundPacket, OutboundPacket};
+use discv5::{DefaultProtocolId, Executor, ListenConfig};
+use std::net::SocketAddr;
+use std::sync::Arc;
+use tokio::net::UdpSocket;
+use tokio::sync::mpsc;
+use tokio::sync::mpsc::{Receiver, Sender};
+use tracing::warn;
+
+pub(crate) const MAX_PACKET_SIZE: usize = 1280;
+
+pub(crate) struct Socket {
+    pub recv: Receiver<InboundPacket>,
+    pub send: Sender<OutboundPacket>,
+}
+
+impl Socket {
+    pub(crate) async fn new(
+        executor: Box<dyn Executor + Send + Sync>,
+        node_id: NodeId,
+        listen_config: ListenConfig,
+    ) -> Self {
+        let socket = match listen_config {
+            ListenConfig::Ipv4 { ip, port } => {
+                let socket_addr: SocketAddr = (ip, port).into();
+                Arc::new(UdpSocket::bind(socket_addr).await.unwrap())
+            }
+            ListenConfig::Ipv6 { .. } => unreachable!(),
+            ListenConfig::DualStack { .. } => unreachable!(),
+        };
+
+        let from_recv_handler = RecvHandler::spawn(executor.clone(), node_id, socket.clone());
+        let to_send_handler = SendHandler::spawn(executor, socket);
+
+        Socket {
+            recv: from_recv_handler,
+            send: to_send_handler,
+        }
+    }
+}
+
+struct RecvHandler {
+    node_id: NodeId,
+    socket: Arc<UdpSocket>,
+    handler_send: mpsc::Sender<InboundPacket>,
+}
+
+impl RecvHandler {
+    pub(crate) fn spawn(
+        executor: Box<dyn Executor>,
+        node_id: NodeId,
+        socket: Arc<UdpSocket>,
+    ) -> Receiver<InboundPacket> {
+        // create the channel to send decoded packets to the handler
+        let (handler_send, handler_recv) = mpsc::channel(30);
+
+        let receive_handler = RecvHandler {
+            node_id,
+            socket,
+            handler_send,
+        };
+
+        executor.spawn(Box::pin(async move {
+            receive_handler.start().await;
+        }));
+
+        handler_recv
+    }
+
+    async fn start(&self) {
+        loop {
+            let mut first_buffer = [0; MAX_PACKET_SIZE];
+
+            if let Ok((length, src_address)) = self.socket.recv_from(&mut first_buffer).await {
+                // self.handle_inbound(src, length, &first_buffer).await;
+                let (packet, authenticated_data) = match Packet::decode::<DefaultProtocolId>(
+                    &self.node_id,
+                    &first_buffer[..length],
+                ) {
+                    Ok(p) => p,
+                    Err(e) => {
+                        warn!("Failed to decode packet: {e:?}");
+                        continue;
+                    }
+                };
+
+                let inbound = InboundPacket {
+                    src_address,
+                    header: packet.header,
+                    message: packet.message,
+                    authenticated_data,
+                };
+
+                self.handler_send.send(inbound).await.unwrap_or_else(|e| {
+                    warn!("Could not send packet to handler: {e:?}");
+                })
+            }
+        }
+    }
+}
+
+struct SendHandler {
+    from_handler: Receiver<OutboundPacket>,
+    socket: Arc<UdpSocket>,
+}
+
+impl SendHandler {
+    pub(crate) fn spawn(
+        executor: Box<dyn Executor>,
+        socket: Arc<UdpSocket>,
+    ) -> Sender<OutboundPacket> {
+        let (to_send_handler, from_handler) = mpsc::channel(30);
+
+        let mut send_handler = SendHandler {
+            from_handler,
+            socket,
+        };
+
+        executor.spawn(Box::pin(async move {
+            send_handler.start().await;
+        }));
+
+        to_send_handler
+    }
+
+    async fn start(&mut self) {
+        loop {
+            if let Some(outbound_packet) = self.from_handler.recv().await {
+                let encoded_packet = outbound_packet
+                    .packet
+                    .encode::<DefaultProtocolId>(&outbound_packet.node_address.node_id);
+                let dest = &outbound_packet.node_address.socket_addr;
+                let _ = self.socket.send_to(&encoded_packet, dest).await.unwrap();
+            }
+        }
+    }
+}

--- a/src/sandbox/mod.rs
+++ b/src/sandbox/mod.rs
@@ -1,6 +1,4 @@
-use crate::mock::{
-    Action, Behaviour, CustomResponse, CustomResponseId, Expect, Mock, Request, Response,
-};
+use crate::mock::{Action, Behaviour, Behaviours, CustomResponse, CustomResponseId, DeclarativeBehaviour, Expect, Mock, Request, Response};
 use crate::utils::publish_and_collect;
 use discv5::enr::{CombinedKey, EnrBuilder};
 use discv5::rpc::ResponseBody;
@@ -183,12 +181,8 @@ async fn run_mock(
     // ////////////////////////
     // Start mock
     // ////////////////////////
-    let mut behaviours = VecDeque::new();
-    behaviours.push_back(Behaviour {
-        expect: Expect::MessageWithoutSession,
-        actions: vec![Action::SendWhoAreYou],
-    });
-    // FINDNODE
+    // Sequential: FINDNODE
+    // let mut behaviours = VecDeque::new();
     // behaviours.push_back(Behaviour {
     //     expect: Expect::Handshake(Request::FINDNODE),
     //     action: Action::EstablishSession(Box::new(Action::CaptureRequest)),
@@ -219,37 +213,58 @@ async fn run_mock(
     //         },
     //     ])),
     // });
-    // PING
-    behaviours.push_back(Behaviour {
-        expect: Expect::Handshake(Request::Ping),
-        actions: vec![
-            Action::EstablishSession,
-            Action::CaptureRequest,
-            Action::SendResponse(Response::Custom(vec![CustomResponse {
-                id: CustomResponseId::CapturedRequestId(0),
-                body: ResponseBody::Pong {
-                    enr_seq: discv5_node.enr.seq(),
-                    ip: IpAddr::V4(discv5_node.enr.ip4().unwrap()),
-                    port: 0, // test
-                },
-            }])),
+
+    // Sequential: PING
+    // let mut behaviours = VecDeque::new();
+    // behaviours.push_back(Behaviour {
+    //     expect: Expect::MessageWithoutSession,
+    //     actions: vec![Action::SendWhoAreYou],
+    // });
+    // behaviours.push_back(Behaviour {
+    //     expect: Expect::Handshake(Request::Ping),
+    //     actions: vec![
+    //         Action::EstablishSession,
+    //         Action::CaptureRequest,
+    //         Action::SendResponse(Response::Custom(vec![CustomResponse {
+    //             id: CustomResponseId::CapturedRequestId(0),
+    //             body: ResponseBody::Pong {
+    //                 enr_seq: discv5_node.enr.seq(),
+    //                 ip: IpAddr::V4(discv5_node.enr.ip4().unwrap()),
+    //                 port: 0, // test
+    //             },
+    //         }])),
+    //     ],
+    // });
+    // behaviours.push_back(Behaviour {
+    //     expect: Expect::Message(Request::Ping),
+    //     actions: vec![
+    //         Action::CaptureRequest,
+    //         Action::SendResponse(Response::Custom(vec![CustomResponse {
+    //             id: CustomResponseId::CapturedRequestId(1),
+    //             body: ResponseBody::Pong {
+    //                 enr_seq: discv5_node.enr.seq(),
+    //                 ip: IpAddr::V4(discv5_node.enr.ip4().unwrap()),
+    //                 port: 0, // test
+    //             },
+    //         }])),
+    //     ],
+    // });
+
+    // Declarative
+    let behaviours = Behaviours::Declarative(DeclarativeBehaviour {
+        whoareyou: vec![],
+        message_without_session: vec![
+            Action::SendWhoAreYou
         ],
-    });
-    behaviours.push_back(Behaviour {
-        expect: Expect::Message(Request::Ping),
-        actions: vec![
-            Action::CaptureRequest,
-            Action::SendResponse(Response::Custom(vec![CustomResponse {
-                id: CustomResponseId::CapturedRequestId(1),
-                body: ResponseBody::Pong {
-                    enr_seq: discv5_node.enr.seq(),
-                    ip: IpAddr::V4(discv5_node.enr.ip4().unwrap()),
-                    port: 0, // test
-                },
-            }])),
+        handshake: vec![
+            Action::Ignore("Ignoring handshake messages".to_string())
+        ],
+        message: vec![
+            Action::SendWhoAreYou
         ],
     });
     let mut _mock = Mock::start(enr, enr_key, config, behaviours).await;
+    // let mut _mock = Mock::start(enr, enr_key, config, Behaviours::Sequential(behaviours)).await;
 
     client
         .signal_and_wait(

--- a/src/sandbox/mod.rs
+++ b/src/sandbox/mod.rs
@@ -121,7 +121,7 @@ async fn run_discv5(
     enr_key: CombinedKey,
     config: discv5::Config,
     participants: Vec<InstanceInfo>,
-    target_node_id: NodeId,
+    _target_node_id: NodeId,
 ) -> Result<(), Box<dyn std::error::Error>> {
     // ////////////////////////
     // Start discv5
@@ -256,12 +256,12 @@ async fn run_mock(
     });
 
     // Declarative
-    // let behaviours = Behaviours::Declarative(DeclarativeBehaviour {
-    //     whoareyou: vec![],
-    //     message_without_session: vec![Action::SendWhoAreYou],
-    //     handshake: vec![Action::Ignore("Ignoring handshake message".to_string())],
-    //     message: vec![Action::SendWhoAreYou],
-    // });
+    let _behaviours = Behaviours::Declarative(DeclarativeBehaviour {
+        whoareyou: vec![],
+        message_without_session: vec![Action::SendWhoAreYou],
+        handshake: vec![Action::Ignore("Ignoring handshake message".to_string())],
+        message: vec![Action::SendWhoAreYou],
+    });
     let mut _mock = Mock::start(enr, enr_key, config, Behaviours::Sequential(behaviours)).await;
     // let mut _mock = Mock::start(enr, enr_key, config, Behaviours::Sequential(behaviours)).await;
 

--- a/src/sandbox/mod.rs
+++ b/src/sandbox/mod.rs
@@ -3,10 +3,10 @@ use crate::mock::{
     Mock, Request, Response,
 };
 use crate::utils::publish_and_collect;
-use discv5::enr::{CombinedKey, EnrBuilder};
+use discv5::enr::{CombinedKey, NodeId};
 use discv5::rpc::ResponseBody;
 use discv5::{Discv5, Enr, ListenConfig};
-use enr::{k256, NodeId};
+use enr::k256;
 use rand::{RngCore, SeedableRng};
 use serde::{Deserialize, Serialize};
 use std::collections::VecDeque;
@@ -39,14 +39,14 @@ pub(crate) async fn run(client: Client) -> Result<(), Box<dyn std::error::Error>
 
     let target_enr = {
         let target_key = keypairs.pop().unwrap();
-        EnrBuilder::new("v4").build(&target_key).expect("enr")
+        Enr::builder().build(&target_key).expect("enr")
     };
 
     // ////////////////////////
     // Construct local Enr
     // ////////////////////////
     let enr_key = keypairs.remove(client.global_seq() as usize - 1);
-    let enr = EnrBuilder::new("v4")
+    let enr = Enr::builder()
         .ip(ip)
         .udp4(9000)
         .build(&enr_key)

--- a/src/sandbox/mod.rs
+++ b/src/sandbox/mod.rs
@@ -1,4 +1,6 @@
-use crate::mock::{Action, Behaviour, Expect, Mock, Request};
+use crate::mock::{
+    Action, Behaviour, CustomResponse, CustomResponseId, Expect, Mock, Request, Response,
+};
 use crate::utils::publish_and_collect;
 use discv5::enr::{CombinedKey, EnrBuilder};
 use discv5::{Discv5, Enr, ListenConfig};
@@ -6,8 +8,10 @@ use serde::{Deserialize, Serialize};
 use std::collections::VecDeque;
 use std::net::Ipv4Addr;
 use std::time::Duration;
+use enr::{k256, NodeId};
+use rand::{RngCore, SeedableRng};
 use testground::client::Client;
-use tracing::error;
+use tracing::{error, info};
 
 const STATE_DISCV5_STARTED: &str = "state_discv5_started";
 const STATE_FINISHED: &str = "state_finished";
@@ -25,10 +29,22 @@ pub(crate) async fn run(client: Client) -> Result<(), Box<dyn std::error::Error>
         .data_network_ip()?
         .expect("IP address for the data network");
 
+    // Seed is chosen such that all nodes are in the 256th bucket of bootstrap
+    let seed = 1652;
+    let mut keypairs = generate_deterministic_keypair(3, seed);
+
+    let target_node_id = {
+        let target_key = keypairs.pop().unwrap();
+        let target_enr = EnrBuilder::new("v4")
+            .build(&target_key)
+            .expect("enr");
+        target_enr.node_id()
+    };
+
     // ////////////////////////
     // Construct local Enr
     // ////////////////////////
-    let enr_key = CombinedKey::generate_secp256k1();
+    let enr_key = keypairs.remove(client.global_seq() as usize - 1);
     let enr = EnrBuilder::new("v4")
         .ip(ip)
         .udp4(9000)
@@ -74,7 +90,7 @@ pub(crate) async fn run(client: Client) -> Result<(), Box<dyn std::error::Error>
         .build();
 
     match client.global_seq() {
-        1 => run_discv5(client, enr, enr_key, config, another_instance_info).await?,
+        1 => run_discv5(client, enr, enr_key, config, another_instance_info, target_node_id).await?,
         2 => run_mock(client, enr, enr_key, config).await?,
         _ => unreachable!(),
     }
@@ -88,11 +104,13 @@ async fn run_discv5(
     enr_key: CombinedKey,
     config: discv5::Config,
     another_instance_info: InstanceInfo,
+    target_node_id: NodeId,
 ) -> Result<(), Box<dyn std::error::Error>> {
     // ////////////////////////
     // Start discv5
     // ////////////////////////
     let mut discv5: Discv5 = Discv5::new(enr.clone(), enr_key, config)?;
+    discv5.add_enr(another_instance_info.enr).unwrap();
     discv5.start().await.expect("Start Discovery v5 server");
 
     client
@@ -102,19 +120,31 @@ async fn run_discv5(
         )
         .await?;
 
-    let result = discv5
-        .find_node_designated_peer(another_instance_info.enr.clone(), vec![0])
-        .await;
+    let mut handles = vec![];
+    for _ in 0..2 {
+        let fut = discv5.find_node(target_node_id);
+        handles.push(tokio::spawn(fut));
+    }
+
+    let mut succeeded = true;
+    for h in handles {
+        match h.await.unwrap() {
+            Ok(res) => info!("Response: {:?}", res),
+            Err(e) => {
+                succeeded = false;
+                error!("Request failed: {e}");
+            },
+        }
+    }
 
     client
         .signal_and_wait(STATE_FINISHED, client.run_parameters().test_instance_count)
         .await?;
 
-    println!("result: {result:?}");
-    if result.is_err() {
+    if succeeded {
         client.record_success().await?;
     } else {
-        client.record_failure("the request succeeded.").await?;
+        client.record_failure("").await?;
     }
     Ok(())
 }
@@ -135,11 +165,26 @@ async fn run_mock(
     });
     behaviours.push_back(Behaviour {
         expect: Expect::Handshake(Request::FINDNODE),
-        action: Action::EstablishSession(Box::new(Action::Ignore("test".to_string()))), // TODO
+        action: Action::EstablishSession(Box::new(Action::CaptureRequest)),
+    });
+    let enr2 = {
+        let mut enr2 = enr.clone();
+        enr2.set_udp4(enr.udp4().unwrap() + 1, &enr_key).unwrap();
+        enr2
+    };
+    behaviours.push_back(Behaviour {
+        expect: Expect::Message(Request::FINDNODE),
+        action: Action::SendResponse(Response::Custom(vec![CustomResponse {
+            id: CustomResponseId::CapturedRequestId(0),
+            body: discv5::rpc::ResponseBody::Nodes {
+                total: 2,
+                nodes: vec![enr2],
+            },
+        }])),
     });
     behaviours.push_back(Behaviour {
         expect: Expect::Message(Request::Ping),
-        action: Action::EstablishSession(Box::new(Action::Ignore("test".to_string()))), // TODO
+        action: Action::SendResponse(Response::Default),
     });
     let mut _mock = Mock::start(enr, enr_key, config, behaviours).await;
 
@@ -156,4 +201,25 @@ async fn run_mock(
 
     client.record_success().await?;
     Ok(())
+}
+
+/// Generate `n` deterministic keypairs from a given seed.
+fn generate_deterministic_keypair(n: usize, seed: u64) -> Vec<CombinedKey> {
+    let mut keypairs = Vec::new();
+    for i in 0..n {
+        let sk = {
+            let rng = &mut rand_xorshift::XorShiftRng::seed_from_u64(seed + i as u64);
+            let mut b = [0; 32];
+            loop {
+                // until a value is given within the curve order
+                rng.fill_bytes(&mut b);
+                if let Ok(k) = k256::ecdsa::SigningKey::from_slice(&b) {
+                    break k;
+                }
+            }
+        };
+        let kp = CombinedKey::from(sk);
+        keypairs.push(kp);
+    }
+    keypairs
 }

--- a/src/sandbox/mod.rs
+++ b/src/sandbox/mod.rs
@@ -11,6 +11,7 @@ use rand::{RngCore, SeedableRng};
 use serde::{Deserialize, Serialize};
 use std::collections::VecDeque;
 use std::net::{IpAddr, Ipv4Addr};
+use std::num::NonZeroU16;
 use std::time::Duration;
 use std::vec;
 use testground::client::Client;
@@ -141,8 +142,8 @@ async fn run_discv5(
     let mut handles = vec![];
     for peer in participants.iter().filter(|p| p.seq != client.global_seq()) {
         for _ in 0..2 {
-            // let fut = discv5.send_ping(peer.enr.clone());
-            let fut = discv5.find_node(target_node_id);
+            let fut = discv5.send_ping(peer.enr.clone());
+            // let fut = discv5.find_node(target_node_id);
             handles.push(tokio::spawn(fut));
         }
     }
@@ -177,10 +178,10 @@ async fn run_mock(
     enr: Enr,
     enr_key: CombinedKey,
     config: discv5::Config,
-    _participants: Vec<InstanceInfo>,
+    participants: Vec<InstanceInfo>,
     _target_enr: Enr,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    // let discv5_node = participants.into_iter().find(|p| p.seq == 1).unwrap();
+    let discv5_node = participants.into_iter().find(|p| p.seq == 1).unwrap();
 
     // ////////////////////////
     // Start mock
@@ -219,49 +220,49 @@ async fn run_mock(
     // });
 
     // Sequential: PING
-    // let mut behaviours = VecDeque::new();
-    // behaviours.push_back(Behaviour {
-    //     expect: Expect::MessageWithoutSession,
-    //     actions: vec![Action::SendWhoAreYou],
-    // });
-    // behaviours.push_back(Behaviour {
-    //     expect: Expect::Handshake(Request::Ping),
-    //     actions: vec![
-    //         Action::EstablishSession,
-    //         Action::CaptureRequest,
-    //         Action::SendResponse(Response::Custom(vec![CustomResponse {
-    //             id: CustomResponseId::CapturedRequestId(0),
-    //             body: ResponseBody::Pong {
-    //                 enr_seq: discv5_node.enr.seq(),
-    //                 ip: IpAddr::V4(discv5_node.enr.ip4().unwrap()),
-    //                 port: 0, // test
-    //             },
-    //         }])),
-    //     ],
-    // });
-    // behaviours.push_back(Behaviour {
-    //     expect: Expect::Message(Request::Ping),
-    //     actions: vec![
-    //         Action::CaptureRequest,
-    //         Action::SendResponse(Response::Custom(vec![CustomResponse {
-    //             id: CustomResponseId::CapturedRequestId(1),
-    //             body: ResponseBody::Pong {
-    //                 enr_seq: discv5_node.enr.seq(),
-    //                 ip: IpAddr::V4(discv5_node.enr.ip4().unwrap()),
-    //                 port: 0, // test
-    //             },
-    //         }])),
-    //     ],
-    // });
+    let mut behaviours = VecDeque::new();
+    behaviours.push_back(Behaviour {
+        expect: Expect::MessageWithoutSession,
+        actions: vec![Action::SendWhoAreYou],
+    });
+    behaviours.push_back(Behaviour {
+        expect: Expect::Handshake(Request::Ping),
+        actions: vec![
+            Action::EstablishSession,
+            Action::CaptureRequest,
+            Action::SendResponse(Response::Custom(vec![CustomResponse {
+                id: CustomResponseId::CapturedRequestId(0),
+                body: ResponseBody::Pong {
+                    enr_seq: discv5_node.enr.seq(),
+                    ip: IpAddr::V4(discv5_node.enr.ip4().unwrap()),
+                    port: NonZeroU16::new(9000).unwrap(),
+                },
+            }])),
+        ],
+    });
+    behaviours.push_back(Behaviour {
+        expect: Expect::Message(Request::Ping),
+        actions: vec![
+            Action::CaptureRequest,
+            Action::SendResponse(Response::Custom(vec![CustomResponse {
+                id: CustomResponseId::CapturedRequestId(1),
+                body: ResponseBody::Pong {
+                    enr_seq: discv5_node.enr.seq(),
+                    ip: IpAddr::V4(discv5_node.enr.ip4().unwrap()),
+                    port: NonZeroU16::new(9000).unwrap(),
+                },
+            }])),
+        ],
+    });
 
     // Declarative
-    let behaviours = Behaviours::Declarative(DeclarativeBehaviour {
-        whoareyou: vec![],
-        message_without_session: vec![Action::SendWhoAreYou],
-        handshake: vec![Action::Ignore("Ignoring handshake message".to_string())],
-        message: vec![Action::SendWhoAreYou],
-    });
-    let mut _mock = Mock::start(enr, enr_key, config, behaviours).await;
+    // let behaviours = Behaviours::Declarative(DeclarativeBehaviour {
+    //     whoareyou: vec![],
+    //     message_without_session: vec![Action::SendWhoAreYou],
+    //     handshake: vec![Action::Ignore("Ignoring handshake message".to_string())],
+    //     message: vec![Action::SendWhoAreYou],
+    // });
+    let mut _mock = Mock::start(enr, enr_key, config, Behaviours::Sequential(behaviours)).await;
     // let mut _mock = Mock::start(enr, enr_key, config, Behaviours::Sequential(behaviours)).await;
 
     client

--- a/src/sandbox/mod.rs
+++ b/src/sandbox/mod.rs
@@ -1,4 +1,7 @@
-use crate::mock::{Action, Behaviour, Behaviours, CustomResponse, CustomResponseId, DeclarativeBehaviour, Expect, Mock, Request, Response};
+use crate::mock::{
+    Action, Behaviour, Behaviours, CustomResponse, CustomResponseId, DeclarativeBehaviour, Expect,
+    Mock, Request, Response,
+};
 use crate::utils::publish_and_collect;
 use discv5::enr::{CombinedKey, EnrBuilder};
 use discv5::rpc::ResponseBody;
@@ -253,15 +256,9 @@ async fn run_mock(
     // Declarative
     let behaviours = Behaviours::Declarative(DeclarativeBehaviour {
         whoareyou: vec![],
-        message_without_session: vec![
-            Action::SendWhoAreYou
-        ],
-        handshake: vec![
-            Action::Ignore("Ignoring handshake messages".to_string())
-        ],
-        message: vec![
-            Action::SendWhoAreYou
-        ],
+        message_without_session: vec![Action::SendWhoAreYou],
+        handshake: vec![Action::Ignore("Ignoring handshake messages".to_string())],
+        message: vec![Action::SendWhoAreYou],
     });
     let mut _mock = Mock::start(enr, enr_key, config, behaviours).await;
     // let mut _mock = Mock::start(enr, enr_key, config, Behaviours::Sequential(behaviours)).await;

--- a/src/sandbox/mod.rs
+++ b/src/sandbox/mod.rs
@@ -120,7 +120,7 @@ async fn run_discv5(
     enr_key: CombinedKey,
     config: discv5::Config,
     participants: Vec<InstanceInfo>,
-    _target_node_id: NodeId,
+    target_node_id: NodeId,
 ) -> Result<(), Box<dyn std::error::Error>> {
     // ////////////////////////
     // Start discv5
@@ -141,8 +141,8 @@ async fn run_discv5(
     let mut handles = vec![];
     for peer in participants.iter().filter(|p| p.seq != client.global_seq()) {
         for _ in 0..2 {
-            let fut = discv5.send_ping(peer.enr.clone());
-            // let fut = discv5.find_node(target_node_id);
+            // let fut = discv5.send_ping(peer.enr.clone());
+            let fut = discv5.find_node(target_node_id);
             handles.push(tokio::spawn(fut));
         }
     }
@@ -177,10 +177,11 @@ async fn run_mock(
     enr: Enr,
     enr_key: CombinedKey,
     config: discv5::Config,
-    participants: Vec<InstanceInfo>,
+    _participants: Vec<InstanceInfo>,
     _target_enr: Enr,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let discv5_node = participants.into_iter().find(|p| p.seq == 1).unwrap();
+    // let discv5_node = participants.into_iter().find(|p| p.seq == 1).unwrap();
+
     // ////////////////////////
     // Start mock
     // ////////////////////////
@@ -257,7 +258,7 @@ async fn run_mock(
     let behaviours = Behaviours::Declarative(DeclarativeBehaviour {
         whoareyou: vec![],
         message_without_session: vec![Action::SendWhoAreYou],
-        handshake: vec![Action::Ignore("Ignoring handshake messages".to_string())],
+        handshake: vec![Action::Ignore("Ignoring handshake message".to_string())],
         message: vec![Action::SendWhoAreYou],
     });
     let mut _mock = Mock::start(enr, enr_key, config, behaviours).await;

--- a/src/talk/mod.rs
+++ b/src/talk/mod.rs
@@ -64,14 +64,17 @@ pub(super) async fn run(client: Client) -> Result<(), Box<dyn std::error::Error>
         .signal_and_wait(STATE_READY_TO_START_SIM, run_parameters.test_instance_count)
         .await?;
 
-    let protocol: Vec<u8> = vec![1];
-    let request: Vec<u8> = vec![1, 2, 3];
-    let response: Vec<u8> = vec![4, 5, 6];
+    let protocol = "PROTOCOL".as_bytes();
+    let request = "A REQUEST".as_bytes();
+    let response = "A RESPONSE".as_bytes();
 
     let test_result = match client.global_seq() {
         1 => {
             // Send TALKREQ
-            match discv5.talk_req(another_node.enr, protocol, request).await {
+            match discv5
+                .talk_req(another_node.enr, protocol.to_vec(), request.to_vec())
+                .await
+            {
                 Ok(talk_response) => {
                     if talk_response == response {
                         Ok(())
@@ -91,8 +94,8 @@ pub(super) async fn run(client: Client) -> Result<(), Box<dyn std::error::Error>
             while let Some(event) = event_stream.recv().await {
                 match event {
                     Event::TalkRequest(talk_request) => {
-                        if talk_request.protocol() == &protocol && talk_request.body() == &request {
-                            if let Err(e) = talk_request.respond(response.clone()) {
+                        if talk_request.protocol() == protocol && talk_request.body() == request {
+                            if let Err(e) = talk_request.respond(response.to_vec()) {
                                 result = Err(e.to_string());
                             }
                         } else {

--- a/src/talk/mod.rs
+++ b/src/talk/mod.rs
@@ -1,0 +1,124 @@
+use crate::utils::publish_and_collect;
+use discv5::enr::CombinedKey;
+use discv5::{Discv5, Enr, Event, ListenConfig};
+use serde::{Deserialize, Serialize};
+use testground::client::Client;
+use tracing::{debug, info};
+
+const STATE_READY_TO_START_SIM: &str = "state_ready_to_start_sim";
+const STATE_FINISHED: &str = "state_finished";
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+struct InstanceInfo {
+    // The sequence number of this test instance within the test.
+    seq: u64,
+    enr: Enr,
+}
+
+pub(super) async fn run(client: Client) -> Result<(), Box<dyn std::error::Error>> {
+    let run_parameters = client.run_parameters();
+
+    assert_eq!(run_parameters.test_instance_count, 2);
+
+    // ////////////////////////
+    // Construct local Enr
+    // ////////////////////////
+    let enr_key = CombinedKey::generate_secp256k1();
+    let enr = Enr::builder()
+        .ip(run_parameters
+            .data_network_ip()?
+            .expect("IP address for the data network"))
+        .udp4(9000)
+        .build(&enr_key)
+        .expect("Construct an Enr");
+
+    info!("ENR: {:?}", enr);
+    info!("NodeId: {}", enr.node_id());
+
+    // //////////////////////////////////////////////////////////////
+    // Start Discovery v5 server
+    // //////////////////////////////////////////////////////////////
+    let mut discv5: Discv5 = Discv5::new(
+        enr,
+        enr_key,
+        discv5::ConfigBuilder::new(ListenConfig::default()).build(),
+    )?;
+    discv5.start().await.expect("Start Discovery v5 server");
+
+    // //////////////////////////////////////////////////////////////
+    // Collect information of all participants in the test case
+    // //////////////////////////////////////////////////////////////
+    let instance_info = InstanceInfo {
+        seq: client.global_seq(),
+        enr: discv5.local_enr(),
+    };
+    debug!("instance_info: {:?}", instance_info);
+
+    let another_node = publish_and_collect(&client, instance_info.clone())
+        .await?
+        .into_iter()
+        .find(|info| info.seq != client.global_seq())
+        .unwrap();
+
+    client
+        .signal_and_wait(STATE_READY_TO_START_SIM, run_parameters.test_instance_count)
+        .await?;
+
+    let protocol: Vec<u8> = vec![1];
+    let request: Vec<u8> = vec![1, 2, 3];
+    let response: Vec<u8> = vec![4, 5, 6];
+
+    let test_result = match client.global_seq() {
+        1 => {
+            // Send TALKREQ
+            match discv5.talk_req(another_node.enr, protocol, request).await {
+                Ok(talk_response) => {
+                    if talk_response == response {
+                        Ok(())
+                    } else {
+                        Err(format!(
+                            "Invalid response. expected: {response:?}, actual: {talk_response:?}"
+                        ))
+                    }
+                }
+                Err(e) => Err(e.to_string()),
+            }
+        }
+        2 => {
+            // Respond TALKREQ
+            let mut event_stream = discv5.event_stream().await.unwrap();
+            let mut result = Ok(());
+            while let Some(event) = event_stream.recv().await {
+                match event {
+                    Event::TalkRequest(talk_request) => {
+                        if talk_request.protocol() == &protocol && talk_request.body() == &request {
+                            if let Err(e) = talk_request.respond(response.clone()) {
+                                result = Err(e.to_string());
+                            }
+                        } else {
+                            result = Err(format!(
+                                "Invalid request. expected: {request:?}, actual: {talk_request:?}"
+                            ));
+                        }
+                        break;
+                    }
+                    _ => continue,
+                }
+            }
+            result
+        }
+        _ => unreachable!(),
+    };
+
+    client
+        .signal_and_wait(STATE_FINISHED, client.run_parameters().test_instance_count)
+        .await?;
+
+    if let Err(e) = test_result {
+        client.record_failure(e).await.unwrap();
+    } else {
+        client.record_success().await?;
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
Added new test case for testing concurrent requests.

## concurrent-requests


```bash
testground run single \
  --plan=discv5-testground \
  --testcase=concurrent-requests \
  --builder=docker:generic \
  --runner=local:docker \
  --instances=2 \
  --wait
```

```mermaid

sequenceDiagram
    participant Node1
    participant Node2
    Note over Node1: Start discv5 server
    Note over Node2: Start discv5 server

    rect rgb(10, 10, 10)
    Note left of Node1: They communicate with each other<br> to establish a session.
    Node1 ->> Node2: message
    Node2 ->> Node1: message
    Note over Node1,Node2: Session established
    end

    rect rgb(100, 100, 0)
    Note right of Node2: In this test case, Node2 session timeout <br>is set to short term (a few seconds)<br> to reproduce session expiration.
    Note over Node2: Session expired
    end

    rect rgb(10, 10, 10)
    Note left of Node1: Node1 sends multiple requests<br> **in parallel**.
    par 
    Node1 ->> Node2: FINDNODE
    and 
    Node1 ->> Node2: FINDNODE
    end
    end

```

## concurrent-requests_whoareyou-timeout

A test case where WHOAREYOU packet times out.

```bash
testground run single \
  --plan=discv5-testground \
  --testcase=concurrent-requests_whoareyou-timeout \
  --builder=docker:generic \
  --runner=local:docker \
  --instances=2 \
  --wait
```

```mermaid
sequenceDiagram
    participant Node1
    participant Node2

    Node2 ->> Node1: Random packet
    Node1 ->> Node2: WHOAREYOU
    rect rgb(100, 100, 0)
    Note over Node2: ** Discard the WHOAREYOU packet<br>to reproduce kind of network issue. **
    end

    rect rgb(10, 10, 10)
    Note left of Node1: Node1 want to send FINDNODE to Node2<br>but active_challenge exists.<br>So insert requests into pending_requests.
    par 
    Note over Node1: pending_requests.insert()
    and 
    Note over Node1: pending_requests.insert()
    end
    end

    rect rgb(100, 100, 0)
    Note over Node1: The challenge in active_challenges<br>has been expired.
    end

```

## concurrent-requests_before-establishing-session

A test case where a node attempts to send requests in parallel before establishing a session.

```bash
testground run single \
  --plan=discv5-testground \
  --testcase=concurrent-requests_before-establishing-session \
  --builder=docker:generic \
  --runner=local:docker \
  --instances=2 \
  --wait
```

```mermaid
sequenceDiagram
    participant Node1
    participant Node2

    Note over Node1: No session with Node2

    rect rgb(10, 10, 10)
    Note left of Node1: Node1 attempts to send multiple requests in parallel <br> but no session with Node2.<br> So Node1 sends a random packet for the first request, <br>and the rest of the requests are inserted into pending_requests.
    par
    Node1 ->> Node2: Random packet (id:1)
    Note over Node1: Insert the request into `active_requests`
    and
    Note over Node1: Insert Request(id:2) into *pending_requests*
    and
    Note over Node1: Insert Request(id:3) into *pending_requests*
    end
    end

    Node2 ->> Node1: WHOAREYOU (id:1)

    Note over Node1: New session established with Node2

    rect rgb(0, 100, 0)
    Note over Node1: Send pending requests since a session has been established.
    Node1 ->> Node2: Request (id:2)
    Node1 ->> Node2: Request (id:3)
    end

    Node1 ->> Node2: Handshake message (id:1)

    Note over Node2: New session established with Node1

    Node2 ->> Node1: Response (id:2)
    Node2 ->> Node1: Response (id:3)
    Node2 ->> Node1: Response (id:1)

    Note over Node1: The request (id:2) completed.
    Note over Node1: The request (id:3) completed.
    Note over Node1: The request (id:1) completed.
```

## sandbox

```bash
testground run single \
  --plan=discv5-testground \
  --testcase=sandbox \
  --builder=docker:generic \
  --runner=local:docker \
  --instances=2 \
  --wait
```


```mermaid
sequenceDiagram
    participant Node1
    participant Node2

    Note left of Node1: Node1 attempts to send two requests(id:1 and id2)<br> in parallel
    Note right of Node2: Node2 doesn't send responses <br>but only WHOAREYOU

    Node1 ->> Node2: Random packet(id:1)
    Note over Node1: Insert Request(id:2) into `pending_requests`
    Node1 ->> Node1: Request(id:2)

    Node2 -->> Node1: WHOAREYOU(id:1)

    rect rgb(10, 10, 10)
    Note over Node1: New session
    Node1 ->> Node2: Handshake message(id:1)
    Note over Node2: Ignore Handshake message(id:1)
    Note over Node1: Send pending requests
    Node1 ->> Node2: Request(id:2)
    Node2 -->> Node1: WHOAREYOU(id:2)
    end

    rect rgb(10, 10, 10)
    Note over Node1: New session
    Node1 ->> Node2: Handshake message(id:2)
    Note over Node2: Ignore Handshake message(id:2)
    Note over Node1: Replay active requests
    Node1 ->> Node2: Request(id:1)
    Node2 -->> Node1: WHOAREYOU(id:1)
    end 

    rect rgb(10, 10, 10)
    rect rgb(10, 100, 10)
    Note over Node1: Handshake message(id:1) already sent
    Note over Node1: Request(id:1) failed
    Note over Node1: Request(id:2) failed
    end
    end
```
